### PR TITLE
Fix receipt backend retrieval from CreateReceipt task

### DIFF
--- a/ESSArch_Core/fixity/receipt/__init__.py
+++ b/ESSArch_Core/fixity/receipt/__init__.py
@@ -11,10 +11,10 @@ extra_receipt_backends = getattr(settings, 'ESSARCH_RECEIPT_BACKENDS', {})
 AVAILABLE_RECEIPT_BACKENDS.update(extra_receipt_backends)
 
 
-def get_backend(name, *args, **kwargs):
+def get_backend(name):
     try:
         module_name, klass = AVAILABLE_RECEIPT_BACKENDS[name].rsplit('.', 1)
     except KeyError:
         raise ValueError('Receipt backend "%s" not found' % name)
 
-    return getattr(importlib.import_module(module_name), klass)(*args, **kwargs)
+    return getattr(importlib.import_module(module_name), klass)()

--- a/ESSArch_Core/ip/tasks.py
+++ b/ESSArch_Core/ip/tasks.py
@@ -238,7 +238,7 @@ class CreateReceipt(DBTask):
         if date is None:
             date = timezone.now()
 
-        backend = get_receipt_backend(backend, ip)
+        backend = get_receipt_backend(backend)
         if task is None:
             task = self.task_id
         backend.create(template, destination, outcome, short_message, message, date, ip=ip, task=task)


### PR DESCRIPTION
Receipt backends does not accept any initialisation arguments since #100 