### PR TITLE
Fix and test list of tasks in step api

### DIFF
--- a/ESSArch_Core/WorkflowEngine/tests/test_views.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_views.py
@@ -237,6 +237,22 @@ class GetAuthorizedStepsTests(TestCase):
         self.assertEqual(response.data, [])
 
 
+class GetStepTasksTests(TestCase):
+    def test_get_step_tasks(self):
+        client = APIClient()
+        user = User.objects.create(username='user')
+        client.force_authenticate(user=user)
+
+        step = ProcessStep.objects.create()
+        task_in_step = ProcessTask.objects.create(processstep=step)
+        ProcessTask.objects.create(name="task outside of step")
+
+        url = reverse('steps-tasks-list', args=(step.pk,))
+        response = client.get(url)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], str(task_in_step.pk))
+
+
 class CreateStepTests(TestCase):
     def setUp(self):
         self.client = APIClient()

--- a/ESSArch_Core/WorkflowEngine/views.py
+++ b/ESSArch_Core/WorkflowEngine/views.py
@@ -132,7 +132,7 @@ class ProcessTaskViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
         queryset = ProcessTask.objects.select_related('responsible').filter(
             Q(information_package__in=ips) | Q(information_package__isnull=True)
         ).distinct()
-        return queryset
+        return self.filter_queryset_by_parents_lookups(queryset)
 
     def get_serializer_class(self):
         if self.action == 'list':

--- a/ESSArch_Core/testapp/urls.py
+++ b/ESSArch_Core/testapp/urls.py
@@ -12,7 +12,12 @@ router.register(r'appraisal-jobs', AppraisalJobViewSet)
 router.register(r'conversion-jobs', ConversionJobViewSet)
 router.register(r'information-packages', InformationPackageViewSet)
 router.register(r'profiles', ProfileViewSet)
-router.register(r'steps', ProcessStepViewSet)
+router.register(r'steps', ProcessStepViewSet).register(
+    r'tasks',
+    ProcessTaskViewSet,
+    base_name='steps-tasks',
+    parents_query_lookups=['processstep']
+)
 router.register(r'submission-agreements', SubmissionAgreementViewSet)
 router.register(r'tasks', ProcessTaskViewSet)
 router.register(r'workarea-entries', WorkareaEntryViewSet, base_name='workarea-entries')


### PR DESCRIPTION
This ensures that `/api/steps/{step_id}/tasks/` only returns tasks that belongs to the step. Regression in #19 