### PR TITLE
Simplify migrations for ConsignMethod

### DIFF
--- a/ESSArch_Core/ip/migrations/0081_auto_20190930_1112.py
+++ b/ESSArch_Core/ip/migrations/0081_auto_20190930_1112.py
@@ -39,11 +39,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='order',
-            name='consign_method',
-            field=models.CharField(blank=True, max_length=255),
-        ),
-        migrations.AddField(
-            model_name='order',
             name='family_name',
             field=models.CharField(blank=True, max_length=255),
         ),

--- a/ESSArch_Core/ip/migrations/0082_auto_20190930_1553.py
+++ b/ESSArch_Core/ip/migrations/0082_auto_20190930_1553.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
                 'verbose_name_plural': 'consign methods',
             },
         ),
-        migrations.AlterField(
+        migrations.AddField(
             model_name='order',
             name='consign_method',
             field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to='ip.ConsignMethod', verbose_name='consign method'),


### PR DESCRIPTION
Earlier if there was any data in the Order table there could be errors when the consign_method field was changed from a CharField to a ForeignKey (int).

Reported error in MariaDB:

```
django.db.utils.DataError: (1265, "Data truncated for column 'consign_method_id' at row 1")
```