### PR TITLE
Set default permission class for all views to ActionPermissions

### DIFF
--- a/ESSArch_Core/api/tests/test_filters.py
+++ b/ESSArch_Core/api/tests/test_filters.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django_filters import rest_framework as filters
-from rest_framework import generics, serializers
+from rest_framework import generics, permissions, serializers
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from ESSArch_Core.api.filters import ListFilter, SearchFilter
@@ -40,6 +40,7 @@ class SearchFilterTests(TestCase):
 
         class SearchListView(generics.ListAPIView):
             queryset = InformationPackage.objects.all()
+            permission_classes = (permissions.IsAuthenticated,)
             serializer_class = SearchFilterSerializer
             filter_backends = (SearchFilter,)
             search_fields = ('id',)

--- a/ESSArch_Core/auth/tests/test_decorators.py
+++ b/ESSArch_Core/auth/tests/test_decorators.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import TestCase
-from rest_framework import status
+from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.test import APIRequestFactory, force_authenticate
 from rest_framework.views import APIView
@@ -16,6 +16,8 @@ class PermissionRequiredOr403Tests(TestCase):
 
     def test_no_permission(self):
         class TestView(APIView):
+            permission_classes = (permissions.IsAuthenticated,)
+
             @permission_required_or_403('ip.add_informationpackage')
             def get(self, request, format=None):
                 return Response({})
@@ -28,6 +30,8 @@ class PermissionRequiredOr403Tests(TestCase):
 
     def test_permission(self):
         class TestView(APIView):
+            permission_classes = (permissions.IsAuthenticated,)
+
             @permission_required_or_403('ip.add_informationpackage')
             def get(self, request, format=None):
                 return Response({})
@@ -42,6 +46,8 @@ class PermissionRequiredOr403Tests(TestCase):
 
     def test_multiple_permissions_granted(self):
         class TestView(APIView):
+            permission_classes = (permissions.IsAuthenticated,)
+
             @permission_required_or_403(['ip.add_informationpackage', 'ip.delete_informationpackage'])
             def get(self, request, format=None):
                 return Response({})
@@ -57,6 +63,8 @@ class PermissionRequiredOr403Tests(TestCase):
 
     def test_multiple_permissions_when_not_all_granted(self):
         class TestView(APIView):
+            permission_classes = (permissions.IsAuthenticated,)
+
             @permission_required_or_403([
                 'ip.add_informationpackage',
                 'ip.delete_informationpackage',
@@ -76,6 +84,8 @@ class PermissionRequiredOr403Tests(TestCase):
 
     def test_multiple_permissions_granted_none_global_perms(self):
         class TestView(APIView):
+            permission_classes = (permissions.IsAuthenticated,)
+
             @permission_required_or_403(
                 ['ip.add_informationpackage', 'ip.delete_informationpackage'],
                 accept_global_perms=False

--- a/ESSArch_Core/config/settings.py
+++ b/ESSArch_Core/config/settings.py
@@ -58,7 +58,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.BasicAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
-        'rest_framework.permissions.IsAuthenticated',
+        'ESSArch_Core.auth.permissions.ActionPermissions',
     ),
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -205,8 +205,8 @@ class EventIPViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
 
 
 class WorkareaEntryViewSet(mixins.DestroyModelMixin, viewsets.ReadOnlyModelViewSet):
-
     queryset = Workarea.objects.all()
+    permission_classes = (permissions.IsAuthenticated,)
     serializer_class = WorkareaSerializer
 
     def get_queryset(self):
@@ -346,6 +346,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
     logger = logging.getLogger('essarch.InformationPackageViewSet')
 
     queryset = InformationPackage.objects.none()
+    permission_classes = (permissions.IsAuthenticated,)
     serializer_class = InformationPackageSerializer
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend, SearchFilter,)
     ordering_fields = (
@@ -2657,6 +2658,8 @@ class WorkareaViewSet(InformationPackageViewSet):
 
 
 class WorkareaFilesViewSet(viewsets.ViewSet, PaginatedViewMixin):
+    permission_classes = (permissions.IsAuthenticated,)
+
     def get_user(self, request):
         requested_user = self.request.query_params.get('user')
         if requested_user in EMPTY_VALUES or requested_user == str(request.user.pk):

--- a/ESSArch_Core/tags/views.py
+++ b/ESSArch_Core/tags/views.py
@@ -3,7 +3,7 @@ from django.db.models import ProtectedError, Q
 from django.utils.translation import ugettext_lazy as _
 from django_filters.rest_framework import DjangoFilterBackend
 from mptt.templatetags.mptt_tags import cache_tree_children
-from rest_framework import exceptions, filters, viewsets
+from rest_framework import exceptions, filters, permissions, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
@@ -79,6 +79,7 @@ class ArchiveViewSet(NestedViewSetMixin, viewsets.ModelViewSet):
     queryset = AgentTagLink.objects.filter(
         tag__elastic_index='archive'
     )
+    permission_classes = (permissions.IsAuthenticated,)
     serializer_class = AgentArchiveLinkSerializer
     filter_backends = (OrderingFilter, SearchFilter,)
     search_fields = ('tag__name',)


### PR DESCRIPTION
By default we want all views to be protected by permissions to ensure that we don't miss any new views that we don't do any custom changes to.