### PR TITLE
Fix bug with form rendering when trying to edit archive with unpublished structure

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/ArchiveModalInstanceCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/ArchiveModalInstanceCtrl.js
@@ -60,7 +60,6 @@ export default class ArchiveModalInstanceCtrl {
             });
             const promises = [];
             toAdd.forEach(function(x) {
-              x.disabled = true;
               promises.push(
                 $http.get(appConfig.djangoUrl + 'structures/' + x + '/').then(function(response) {
                   response.data.name_with_version = StructureName.getNameWithVersion(response.data);


### PR DESCRIPTION
The javascript code is trying to set "disabled" property of uuid string and prevents edit form from rendering. 
Occurs when an archives structure is not published.