### PR TITLE
Fix XML comparison in package representations

### DIFF
--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -529,7 +529,7 @@ class XMLGenerator:
 
                 if path not in found_paths:
                     found_paths.append(path)
-                    dirs.append((x['-file'], x['-dir'], x['-specification'], spec['data']))
+                    dirs.append((x['-file'], x['-dir'], x['-specification'], x.get('-pointer'), spec['data']))
 
         return dirs
 
@@ -570,7 +570,7 @@ class XMLGenerator:
             if external:
                 external_gen = XMLGenerator()
 
-            for ext_file, ext_dir, ext_spec, ext_data in external:
+            for ext_file, ext_dir, ext_spec, ext_pointer, ext_data in external:
                 ext_sub_dirs = next(walk(os.path.join(folderToParse, ext_dir)))[1]
                 for sub_dir in ext_sub_dirs:
                     ptr_file_path = os.path.join(ext_dir, sub_dir, ext_file)
@@ -584,10 +584,10 @@ class XMLGenerator:
                     }
                     external_gen.generate(external_to_create, os.path.join(folderToParse, ext_dir, sub_dir))
 
-                    filepath = os.path.join(folderToParse, ptr_file_path)
-
-                    fileinfo = parse_file(filepath, self.fid, ptr_file_path, algorithm=algorithm, rootdir=sub_dir)
-                    files.append(fileinfo)
+                    if ext_pointer is not None:
+                        filepath = os.path.join(folderToParse, ptr_file_path)
+                        fileinfo = parse_file(filepath, self.fid, ptr_file_path, algorithm=algorithm, rootdir=sub_dir)
+                        files.append(fileinfo)
 
             files.extend(parse_files(self.fid, folderToParse, external, algorithm, rootdir=""))
 

--- a/ESSArch_Core/fixity/serializers.py
+++ b/ESSArch_Core/fixity/serializers.py
@@ -4,9 +4,11 @@ from ESSArch_Core.fixity.models import Validation
 
 
 class ValidationSerializer(serializers.ModelSerializer):
+    specification = serializers.JSONField(read_only=True)
+
     class Meta:
         model = Validation
-        fields = ('id', 'filename', 'validator', 'passed', 'message',
+        fields = ('id', 'filename', 'validator', 'passed', 'message', 'specification',
                   'information_package', 'time_started', 'time_done', 'required', 'task')
 
 

--- a/ESSArch_Core/frontend/static/frontend/lang/en/stateTree.ts
+++ b/ESSArch_Core/frontend/static/frontend/lang/en/stateTree.ts
@@ -7,6 +7,7 @@ export default ($translateProvider: ng.translate.ITranslateProvider) => {
       DURATION: 'Duration',
       RUNNING: 'Running',
       VALIDATIONS: 'Validations',
+      REPRESENTATION: 'Representation',
     },
   });
 };

--- a/ESSArch_Core/frontend/static/frontend/lang/sv/stateTree.ts
+++ b/ESSArch_Core/frontend/static/frontend/lang/sv/stateTree.ts
@@ -7,6 +7,7 @@ export default ($translateProvider: ng.translate.ITranslateProvider) => {
       DURATION: 'Varaktighet',
       RUNNING: 'Körs',
       VALIDATIONS: 'Valideringar',
+      REPRESENTATION: 'Representation',
     },
   });
 };

--- a/ESSArch_Core/frontend/static/frontend/views/modals/task_info_modal.html
+++ b/ESSArch_Core/frontend/static/frontend/views/modals/task_info_modal.html
@@ -210,6 +210,9 @@
                 <th st-sort="validator" class="cursor-pointer">
                   {{ "VALIDATOR" | translate }}
                 </th>
+                <th>
+                  {{ "STATE_TREE.REPRESENTATION" | translate }}
+                </th>
                 <th st-sort="filename" class="cursor-pointer">
                   {{ "FILENAME" | translate }}
                 </th>
@@ -257,6 +260,9 @@
                 </td>
                 <td class="text-oneline-ellipsis">
                   {{ x.validator }}
+                </td>
+                <td class="text-oneline-ellipsis">
+                  {{ x.specification.options.representation }}
                 </td>
                 <td class="text-oneline-ellipsis">
                   {{ x.filename }}

--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -920,6 +920,12 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
                         "if": generate_premis,
                         "label": "Compare premis and content-mets",
                         "args": ["{{_PREMIS_PATH}}", "{{_CONTENT_METS_PATH}}"],
+                        "params": {'recursive': False},
+                    },
+                    {
+                        "name": "ESSArch_Core.tasks.CompareRepresentationXMLFiles",
+                        "if": generate_premis,
+                        "label": "Compare representation premis and mets",
                     }
                 ]
             },
@@ -2319,6 +2325,12 @@ class InformationPackageReceptionViewSet(viewsets.ViewSet, PaginatedViewMixin):
                                 "if": generate_premis,
                                 "label": "Compare premis and content-mets",
                                 "args": ["{{_PREMIS_PATH}}", "{{_CONTENT_METS_PATH}}"],
+                                "params": {'recursive': False},
+                            },
+                            {
+                                "name": "ESSArch_Core.tasks.CompareRepresentationXMLFiles",
+                                "if": generate_premis,
+                                "label": "Compare representation premis and mets",
                             }
                         ]
                     },


### PR DESCRIPTION
The main change here is the addition of the CompareRepresentationXMLFiles task.

This task finds each representation mets referenced by the root mets and
compares each with their respective premis file.

To better represent the result of the validation we also now have a
"representation" column in the validation list in the task detail modal which
shows which representation that each file is in.

In the future this could be improved further by creating a task for each
representation at "task runtime" for faster retries.