### PR TITLE
Fix filter performance issue

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/BaseCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/BaseCtrl.js
@@ -144,13 +144,17 @@ export default class BaseCtrl {
           .then(ip => {
             vm.initialSearch = angular.copy($stateParams.id);
             $scope.ipTableClick(ip, {}, {noStateChange: true});
+            vm.createFilterModel();
             $timeout(() => {
               $scope.getListViewData();
             });
           })
           .catch(() => {
+            vm.createFilterModel();
             $state.go($state.current.name, {id: null});
           });
+      } else {
+        vm.createFilterModel();
       }
     };
 
@@ -223,17 +227,16 @@ export default class BaseCtrl {
       })
     );
 
-    vm.setupForm = () => {
-      $timeout(() => {
-        let filters = Filters.getIpFilters($state.current.name);
-        $scope.filterModel = angular.copy(filters.model);
-        vm.initialColumnFilters = angular.copy(filters.model);
-        $scope.columnFilters = angular.copy(filters.model);
-        $scope.fields = filters.fields;
-        console.log('iniftfiltermodel: ', angular.copy(filters.model));
-      });
+    vm.createFilterModel = () => {
+      const model = Filters.getIpFilters($state.current.name).model;
+      $scope.filterModel = angular.copy(model);
+      vm.initialColumnFilters = angular.copy(model);
+      $scope.columnFilters = angular.copy(model);
     };
-    vm.setupForm();
+
+    vm.createFilterFields = () => {
+      $scope.fields = Filters.getIpFilters($state.current.name).fields;
+    };
 
     $scope.$on('REFRESH_LIST_VIEW', function(event, data) {
       $scope.getListViewData();
@@ -1044,7 +1047,8 @@ export default class BaseCtrl {
       }
     };
     vm.clearFilters = function() {
-      vm.setupForm();
+      vm.createFilterModel();
+      vm.createFilterFields();
       $scope.submitAdvancedFilters();
     };
 
@@ -1247,7 +1251,7 @@ export default class BaseCtrl {
         $scope.showAdvancedFilters = false;
       } else {
         if ($scope.fields.length <= 0 || $scope.filterModel === null) {
-          vm.setupForm();
+          vm.createFilterFields();
         }
         $scope.showAdvancedFilters = true;
       }

--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/EventCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/EventCtrl.js
@@ -52,7 +52,7 @@ export default class EventCtrl {
     vm.$onInit = function() {
       $scope.ip = vm.ip;
       vm.getEventlogData();
-      vm.setupForm();
+      vm.createFilterModel();
     };
     vm.$onChanges = function() {
       $scope.addEventAlert = null;
@@ -182,14 +182,16 @@ export default class EventCtrl {
     $scope.filterModel = {};
     $scope.options = {};
     $scope.fields = [];
-    vm.setupForm = function() {
-      $timeout(() => {
-        let filters = Filters.getEventFilters($state.current.name);
-        $scope.filterModel = angular.copy(filters.model);
-        vm.initialColumnFilters = angular.copy(filters.model);
-        $scope.columnFilters = angular.copy(filters.model);
-        $scope.fields = filters.fields;
-      });
+
+    vm.createFilterModel = () => {
+      let model = Filters.getEventFilters($state.current.name).model;
+      $scope.filterModel = angular.copy(model);
+      vm.initialColumnFilters = angular.copy(model);
+      $scope.columnFilters = angular.copy(model);
+    };
+
+    vm.createFilterFields = () => {
+      $scope.fields = Filters.getEventFilters($state.current.name).fields;
     };
 
     //Toggle visibility of advanced filters
@@ -198,7 +200,7 @@ export default class EventCtrl {
         $scope.showAdvancedFilters = false;
       } else {
         if ($scope.fields.length <= 0) {
-          vm.setupForm();
+          vm.createFilterFields();
         }
         $scope.showAdvancedFilters = true;
       }
@@ -229,7 +231,8 @@ export default class EventCtrl {
     };
 
     vm.clearFilters = function() {
-      vm.setupForm();
+      vm.createFilterModel();
+      vm.createFilterFields();
       $scope.submitAdvancedFilters();
     };
 

--- a/ESSArch_Core/frontend/static/frontend/scripts/services/filters.ts
+++ b/ESSArch_Core/frontend/static/frontend/scripts/services/filters.ts
@@ -15,24 +15,31 @@ export default (
   let users: any = [];
   let eventTypes: any = [];
 
-  let getStoragePolicies = async (search: string) => {
-    const response = await $http.get(appConfig.djangoUrl + 'storage-policies/', {
-      params: {page: 1, page_size: 10, search},
+  let getStoragePolicies = (search: string) => {
+    return $http
+      .get(appConfig.djangoUrl + 'storage-policies/', {
+        params: {page: 1, page_size: 10, search},
+      })
+      .then(response => {
+        policies = response.data;
+        return response.data;
+      });
+  };
+
+  let getUsers = (search: string) => {
+    return $http.get(appConfig.djangoUrl + 'users/', {params: {page: 1, page_size: 10, search}}).then(response => {
+      users = response.data;
+      return response.data;
     });
-    policies = response.data;
-    return response.data;
   };
 
-  let getUsers = async (search: string) => {
-    const response = await $http.get(appConfig.djangoUrl + 'users/', {params: {page: 1, page_size: 10, search}});
-    users = response.data;
-    return response.data;
-  };
-
-  let getEventTypes = async (search: string) => {
-    const response = await $http.get(appConfig.djangoUrl + 'event-types/', {params: {page: 1, page_size: 10, search}});
-    eventTypes = response.data;
-    return response.data;
+  let getEventTypes = (search: string) => {
+    return $http
+      .get(appConfig.djangoUrl + 'event-types/', {params: {page: 1, page_size: 10, search}})
+      .then(response => {
+        eventTypes = response.data;
+        return response.data;
+      });
   };
 
   // Base filter fields for information package views


### PR DESCRIPTION
Building IP and event filters took too long due to timeouts.

* Remove $timeout and make the first call to the filter data creation function when selected IP etc is calculated
* Split filter form creation into 2 functions to avoid unneccesary work. The actual fields are now created the first time advanced filter is opened and the default values (form model) is created when page is initialized.