### PR TITLE
Add "migratable" filter for storage mediums

### DIFF
--- a/ESSArch_Core/storage/filters.py
+++ b/ESSArch_Core/storage/filters.py
@@ -53,7 +53,10 @@ class StorageMediumFilter(filters.FilterSet):
         return queryset.deactivatable(include_inactive_ips=include_inactive_ips)
 
     def filter_migratable(self, queryset, name, value):
-        return queryset.migratable()
+        if value:
+            return queryset.migratable()
+        else:
+            return queryset.non_migratable()
 
     class Meta:
         model = StorageMedium

--- a/ESSArch_Core/storage/filters.py
+++ b/ESSArch_Core/storage/filters.py
@@ -41,6 +41,7 @@ class StorageMediumFilter(filters.FilterSet):
     )
     deactivatable = filters.BooleanFilter(label='deactivatable', method='filter_deactivatable')
     include_inactive_ips = filters.BooleanFilter(method='filter_include_inactive_ips')
+    migratable = filters.BooleanFilter(label='migratable', method='filter_migratable')
 
     def filter_include_inactive_ips(self, queryset, *args):
         # this filter is only used together with deactivatable
@@ -50,6 +51,9 @@ class StorageMediumFilter(filters.FilterSet):
         include_inactive_ips = self.request.query_params.get('include_inactive_ips', False)
         include_inactive_ips = include_inactive_ips in (True, 'True', 'true', '1')
         return queryset.deactivatable(include_inactive_ips=include_inactive_ips)
+
+    def filter_migratable(self, queryset, name, value):
+        return queryset.migratable()
 
     class Meta:
         model = StorageMedium

--- a/ESSArch_Core/storage/tests/test_views.py
+++ b/ESSArch_Core/storage/tests/test_views.py
@@ -244,6 +244,11 @@ class StorageMediumMigratableTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
 
+        response = self.client.get(self.url, data={'migratable': False})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], str(self.storage_medium.pk))
+
     def test_migrated_ip(self):
         new_storage_target = StorageTarget.objects.create(name='new')
         new_rel = StorageMethodTargetRelation.objects.create(
@@ -268,6 +273,10 @@ class StorageMediumMigratableTests(TestCase):
         response = self.client.get(self.url, data={'migratable': True})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data, [])
+
+        response = self.client.get(self.url, data={'migratable': False})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
         # Enable new medium
         new_rel.status = STORAGE_TARGET_STATUS_ENABLED

--- a/ESSArch_Core/storage/tests/test_views.py
+++ b/ESSArch_Core/storage/tests/test_views.py
@@ -8,6 +8,7 @@ from ESSArch_Core.configuration.models import Path, StoragePolicy
 from ESSArch_Core.ip.models import InformationPackage
 from ESSArch_Core.storage.models import (
     DISK,
+    STORAGE_TARGET_STATUS_DISABLED,
     STORAGE_TARGET_STATUS_ENABLED,
     STORAGE_TARGET_STATUS_MIGRATE,
     StorageMedium,
@@ -207,6 +208,114 @@ class StorageMediumDeactivatableTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['id'], str(self.storage_medium.pk))
+
+
+class StorageMediumMigratableTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.storage_method = StorageMethod.objects.create()
+        cls.storage_target = StorageTarget.objects.create()
+        cls.storage_method_target_rel = StorageMethodTargetRelation.objects.create(
+            storage_method=cls.storage_method,
+            storage_target=cls.storage_target,
+            status=STORAGE_TARGET_STATUS_ENABLED
+        )
+        cls.storage_medium = StorageMedium.objects.create(
+            storage_target=cls.storage_target,
+            status=20, location_status=50, block_size=1024, format=103,
+        )
+
+        cls.policy = StoragePolicy.objects.create(
+            cache_storage=cls.storage_method,
+            ingest_path=Path.objects.create(entity='test', value='foo')
+        )
+        cls.policy.storage_methods.add(cls.storage_method)
+
+        cls.ip = InformationPackage.objects.create(archived=True, policy=cls.policy)
+        cls.user = User.objects.create(username='user')
+
+    def setUp(self):
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('storagemedium-list')
+
+    def test_no_change(self):
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+    def test_migrated_ip(self):
+        new_storage_target = StorageTarget.objects.create(name='new')
+        new_rel = StorageMethodTargetRelation.objects.create(
+            storage_method=self.storage_method,
+            storage_target=new_storage_target,
+            status=STORAGE_TARGET_STATUS_DISABLED
+        )
+        new_storage_medium = StorageMedium.objects.create(
+            medium_id="new_medium", storage_target=new_storage_target,
+            status=20, location_status=50, block_size=1024, format=103,
+        )
+        self.storage_method_target_rel.status = STORAGE_TARGET_STATUS_MIGRATE
+        self.storage_method_target_rel.save()
+
+        # Add IP to old medium
+        StorageObject.objects.create(
+            ip=self.ip, storage_medium=self.storage_medium,
+            content_location_type=DISK,
+        )
+
+        # New medium exists but it is disabled
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+        # Enable new medium
+        new_rel.status = STORAGE_TARGET_STATUS_ENABLED
+        new_rel.save()
+
+        # New enabled medium exists but no objects are migrated yet
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], str(self.storage_medium.pk))
+
+        # Add IP to new medium
+        StorageObject.objects.create(
+            ip=self.ip, storage_medium=new_storage_medium,
+            content_location_type=DISK,
+        )
+
+        # All objects migrated and old medium is deactivatable
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
+
+        # Add new IP to old medium
+        new_ip = InformationPackage.objects.create(
+            archived=True,
+            policy=self.policy
+        )
+        StorageObject.objects.create(
+            ip=new_ip, storage_medium=self.storage_medium,
+            content_location_type=DISK,
+        )
+
+        # All objects are not migrated
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]['id'], str(self.storage_medium.pk))
+
+        # Add new IP to new medium
+        StorageObject.objects.create(
+            ip=new_ip, storage_medium=new_storage_medium,
+            content_location_type=DISK,
+        )
+
+        # All objects migrated and old medium is deactivatable
+        response = self.client.get(self.url, data={'migratable': True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, [])
 
 
 class StorageMediumDeactivateTests(TestCase):


### PR DESCRIPTION
This filter lets users list storage mediums which has new storage mediums
available for migration to them. It will only list mediums that contain atleast one IP
not yet migrated to the new medium.