### PR TITLE
XML: Compare full relative path when skipping external dirs

### DIFF
--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -2296,8 +2296,11 @@ class ExternalTestCase(TestCase):
 
         tree = etree.parse(self.fname)
 
-        self.assertEqual(len(tree.xpath(".//ptr[text()='%s']" % os.path.relpath(external1_path, self.datadir))), 1)
-        self.assertEqual(len(tree.xpath(".//ptr[text()='%s']" % os.path.relpath(external2_path, self.datadir))), 1)
+        rel_external1 = normalize_path(os.path.relpath(external1_path, self.datadir))
+        rel_external2 = normalize_path(os.path.relpath(external2_path, self.datadir))
+
+        self.assertEqual(len(tree.xpath(".//ptr[text()='%s']" % rel_external1)), 1)
+        self.assertEqual(len(tree.xpath(".//ptr[text()='%s']" % rel_external2)), 1)
 
         self.assertTrue(os.path.isfile(external1_path))
         self.assertTrue(os.path.isfile(external2_path))
@@ -2372,7 +2375,9 @@ class ExternalTestCase(TestCase):
         os.makedirs(nested_external2)
 
         nested_file1 = os.path.join(nested_external1, "nested1.txt")
+        nested_file1 = normalize_path(nested_file1)
         nested_file2 = os.path.join(nested_external2, "nested2.pdf")
+        nested_file2 = normalize_path(nested_file2)
 
         with open(nested_file1, "w") as f:
             f.write('a txt file')
@@ -2384,14 +2389,18 @@ class ExternalTestCase(TestCase):
 
         tree = etree.parse(self.fname)
 
-        self.assertEqual(len(tree.findall(".//file[@href='%s']" % os.path.relpath(nested_file1, self.datadir))), 1)
-        self.assertEqual(len(tree.findall(".//file[@href='%s']" % os.path.relpath(nested_file2, self.datadir))), 1)
+        rel_nested1 = normalize_path(os.path.relpath(nested_file1, self.datadir))
+        rel_nested2 = normalize_path(os.path.relpath(nested_file2, self.datadir))
+        self.assertEqual(len(tree.findall(".//file[@href='%s']" % rel_nested1)), 1)
+        self.assertEqual(len(tree.findall(".//file[@href='%s']" % rel_nested2)), 1)
 
         external1_path = os.path.join(self.external1, 'external.xml')
         external2_path = os.path.join(self.external2, 'external.xml')
+        rel_external1 = normalize_path(os.path.relpath(external1_path, self.datadir))
+        rel_external2 = normalize_path(os.path.relpath(external2_path, self.datadir))
 
-        self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % os.path.relpath(external1_path, self.datadir))), 1)
-        self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % os.path.relpath(external2_path, self.datadir))), 1)
+        self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % rel_external1)), 1)
+        self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % rel_external2)), 1)
 
         self.assertTrue(os.path.isfile(external1_path))
         self.assertTrue(os.path.isfile(external2_path))

--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -2311,9 +2311,20 @@ class ExternalTestCase(TestCase):
     def test_external_with_files(self):
         specification = {
             '-name': 'root',
+            '-children': [
+                {
+                    '-name': 'file',
+                    '-containsFiles': True,
+                    '-attr': [
+                        {
+                            '-name': 'href',
+                            '#content': [{'var': 'href'}]
+                        },
+                    ],
+                },
+            ],
             '-external': {
                 '-dir': 'external',
-                '-file': 'external.xml',
                 '-pointer': {
                     '-name': 'ptr',
                     '-attr': [
@@ -2323,6 +2334,7 @@ class ExternalTestCase(TestCase):
                         },
                     ],
                 },
+                '-file': 'external.xml',
                 '-specification': {
                     '-name': 'mets',
                     '-attr': [
@@ -2347,9 +2359,24 @@ class ExternalTestCase(TestCase):
             },
         }
 
-        with open(os.path.join(self.external1, "file1.txt"), "w") as f:
+        with open(os.path.join(self.external1, "ext1.txt"), "w") as f:
             f.write('a txt file')
-        with open(os.path.join(self.external2, "file1.pdf"), "w") as f:
+        with open(os.path.join(self.external2, "ext2.pdf"), "w") as f:
+            f.write('a pdf file')
+
+        # create nested external files
+        nested_external = os.path.join(self.datadir, "nested/external")
+        nested_external1 = os.path.join(nested_external, "external1")
+        nested_external2 = os.path.join(nested_external, "external2")
+        os.makedirs(nested_external1)
+        os.makedirs(nested_external2)
+
+        nested_file1 = os.path.join(nested_external1, "nested1.txt")
+        nested_file2 = os.path.join(nested_external2, "nested2.pdf")
+
+        with open(nested_file1, "w") as f:
+            f.write('a txt file')
+        with open(nested_file2, "w") as f:
             f.write('a pdf file')
 
         self.generator.generate({self.fname: {'spec': specification}}, folderToParse=self.datadir)
@@ -2357,10 +2384,11 @@ class ExternalTestCase(TestCase):
 
         tree = etree.parse(self.fname)
 
+        self.assertEqual(len(tree.findall(".//file[@href='%s']" % os.path.relpath(nested_file1, self.datadir))), 1)
+        self.assertEqual(len(tree.findall(".//file[@href='%s']" % os.path.relpath(nested_file2, self.datadir))), 1)
+
         external1_path = os.path.join(self.external1, 'external.xml')
         external2_path = os.path.join(self.external2, 'external.xml')
-
-        self.assertIsNone(tree.find('.//file'))
 
         self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % os.path.relpath(external1_path, self.datadir))), 1)
         self.assertEqual(len(tree.findall(".//ptr[@href='%s']" % os.path.relpath(external2_path, self.datadir))), 1)
@@ -2368,11 +2396,14 @@ class ExternalTestCase(TestCase):
         self.assertTrue(os.path.isfile(external1_path))
         self.assertTrue(os.path.isfile(external2_path))
 
+        self.assertIsNone(tree.find(".//file[@href='ext1.txt']"))
+        self.assertIsNone(tree.find(".//file[@href='ext2.pdf']"))
+
         external1_tree = etree.parse(external1_path)
-        self.assertEqual(len(external1_tree.findall(".//file[@href='file1.txt']")), 1)
+        self.assertEqual(len(external1_tree.findall(".//file[@href='ext1.txt']")), 1)
 
         external2_tree = etree.parse(external2_path)
-        self.assertEqual(len(external2_tree.findall(".//file[@href='file1.pdf']")), 1)
+        self.assertEqual(len(external2_tree.findall(".//file[@href='ext2.pdf']")), 1)
 
     def test_external_info(self):
         specification = {

--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -39,6 +39,7 @@ from ESSArch_Core.essxml.util import parse_file
 from ESSArch_Core.fixity.format import FormatIdentifier
 from ESSArch_Core.util import (
     get_elements_without_namespace,
+    in_directory,
     make_unicode,
     nested_lookup,
 )
@@ -143,7 +144,7 @@ def findElementWithoutNamespace(tree, el_name):
 
 
 class XMLElement:
-    def __init__(self, template, nsmap=None):
+    def __init__(self, template, nsmap=None, fid=None):
         if nsmap is None:
             nsmap = {}
 
@@ -176,9 +177,18 @@ class XMLElement:
         self.parent = None
         self.parent_pos = 0
 
+        self._fid = fid
+
         for child in template.get('-children', []):
             child_el = XMLElement(child)
             self.children.append(child_el)
+
+    @property
+    def fid(self):
+        if self._fid is not None:
+            return self._fid
+
+        self._fid = FormatIdentifier()
 
     def parse(self, info):
         return parseContent(self.content, info)
@@ -270,7 +280,7 @@ class XMLElement:
 
         self.el.append(new.el)
 
-    def createLXMLElement(self, info, nsmap=None, files=None, folderToParse='', parent=None):
+    def createLXMLElement(self, info, nsmap=None, files=None, folderToParse='', parent=None, algorithm=None):
         if nsmap is None:
             nsmap = {}
 
@@ -324,14 +334,27 @@ class XMLElement:
             else:
                 for ext_dir in natsorted(ext_dirs):
                     if '-pointer' in self.external:
-                        ptr = XMLElement(self.external['-pointer'])
+                        ptr = XMLElement(self.external['-pointer'], fid=self.fid)
                         ptr_file_path = os.path.join(self.external['-dir'], ext_dir, self.external['-file'])
 
                         ptr_info = info
                         ptr_info['_EXT'] = ext_dir
                         ptr_info['_EXT_HREF'] = ptr_file_path
+
+                        filepath = os.path.join(folderToParse, ptr_file_path)
+                        fileinfo = parse_file(
+                            filepath, self.fid, ptr_file_path, algorithm=algorithm, rootdir=ext_dir
+                        )
+
+                        for k, v in fileinfo.items():
+                            if k[0] == 'F':
+                                ptr_info['_EXT_{}'.format(k[1:])] = v
+                            else:
+                                ptr_info['_EXT_{}'.format(k)] = v
+
                         child_el = ptr.createLXMLElement(
-                            ptr_info, full_nsmap, folderToParse=folderToParse, parent=self
+                            ptr_info, full_nsmap, folderToParse=folderToParse, parent=self,
+                            algorithm=algorithm,
                         )
 
                         if child_el is not None:
@@ -357,7 +380,8 @@ class XMLElement:
                             full_nsmap,
                             files=files,
                             folderToParse=folderToParse,
-                            parent=self
+                            parent=self,
+                            algorithm=algorithm,
                         )
                         if child_el is not None:
                             self.add_element(child)
@@ -387,7 +411,8 @@ class XMLElement:
                         full_nsmap,
                         files=files,
                         folderToParse=folderToParse,
-                        parent=self
+                        parent=self,
+                        algorithm=algorithm,
                     )
                     if child_el is not None:
                         self.add_element(child)
@@ -398,7 +423,8 @@ class XMLElement:
                     full_nsmap,
                     files=files,
                     folderToParse=folderToParse,
-                    parent=self
+                    parent=self,
+                    algorithm=algorithm,
                 )
                 if child_el is not None:
                     self.add_element(child)
@@ -482,12 +508,18 @@ class XMLAttribute:
 
 def find_files_in_path_not_in_external_dirs(fid, path, external, algorithm, rootdir=""):
     files = []
+    external = [e[1] for e in external]
     for root, dirnames, filenames in walk(path):
-        dirnames[:] = [d for d in dirnames if d not in [e[1] for e in external]]
-
         for fname in filenames:
             filepath = os.path.join(root, fname)
             relpath = os.path.relpath(filepath, path)
+
+            in_external = False
+            for e in external:
+                if in_directory(relpath, e):
+                    in_external = True
+            if in_external:
+                continue
 
             fileinfo = parse_file(filepath, fid, relpath, algorithm=algorithm, rootdir=rootdir)
             files.append(fileinfo)
@@ -549,7 +581,7 @@ class XMLGenerator:
                 'file': fname,
                 'template': content['spec'],
                 'data': content.get('data', {}),
-                'root': XMLElement(content['spec'])
+                'root': XMLElement(content['spec'], fid=self.fid)
             })
 
         if extra_paths_to_parse is None:
@@ -596,13 +628,6 @@ class XMLGenerator:
                         }
                         external_gen.generate(external_to_create, os.path.join(folderToParse, ext_dir, sub_dir))
 
-                        if ext_pointer is not None:
-                            filepath = os.path.join(folderToParse, ptr_file_path)
-                            fileinfo = parse_file(
-                                filepath, self.fid, ptr_file_path, algorithm=algorithm, rootdir=sub_dir
-                            )
-                            files.append(fileinfo)
-
             files.extend(parse_files(self.fid, folderToParse, external, algorithm, rootdir=""))
 
         for path in extra_paths_to_parse:
@@ -616,7 +641,7 @@ class XMLGenerator:
             data['_XML_FILENAME'] = os.path.basename(fname)
 
             self.tree = etree.ElementTree(
-                rootEl.createLXMLElement(data, files=files, folderToParse=folderToParse)
+                rootEl.createLXMLElement(data, files=files, folderToParse=folderToParse, algorithm=algorithm)
             )
             self.write(fname)
 

--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -42,6 +42,7 @@ from ESSArch_Core.util import (
     in_directory,
     make_unicode,
     nested_lookup,
+    normalize_path,
 )
 
 logger = logging.getLogger('essarch.essxml.generator')
@@ -336,6 +337,7 @@ class XMLElement:
                     if '-pointer' in self.external:
                         ptr = XMLElement(self.external['-pointer'], fid=self.fid)
                         ptr_file_path = os.path.join(self.external['-dir'], ext_dir, self.external['-file'])
+                        ptr_file_path = normalize_path(ptr_file_path)
 
                         ptr_info = info
                         ptr_info['_EXT'] = ext_dir
@@ -618,6 +620,7 @@ class XMLGenerator:
                 else:
                     for sub_dir in ext_sub_dirs:
                         ptr_file_path = os.path.join(ext_dir, sub_dir, ext_file)
+                        ptr_file_path = normalize_path(ptr_file_path)
 
                         ext_info = copy.deepcopy(ext_data)
                         ext_info['_EXT'] = sub_dir


### PR DESCRIPTION
This fixes cases such as when you have a specified external directory named  `foo` and another non-external directory named `bar/foo`.

Previously files from `bar/foo` would be excluded because we only looked at the basename of each directory. With this change we compare the full relative path, i.e. `bar/foo`.