### PR TITLE
Fix XML validation against schemas with https imports

### DIFF
--- a/ESSArch_Core/essxml/util.py
+++ b/ESSArch_Core/essxml/util.py
@@ -24,6 +24,7 @@
 
 import logging
 import os
+import pathlib
 import tempfile
 import uuid
 from urllib.parse import urlparse
@@ -457,8 +458,9 @@ def download_imported_https_schemas(schema, dst):
         if protocol == 'http':
             continue
         new_path = download_schema(dst, logger, url)
+        new_path = pathlib.Path(new_path)
         el = url.getparent()
-        el.attrib['schemaLocation'] = 'file://{}'.format(new_path)
+        el.attrib['schemaLocation'] = new_path.as_uri()
 
     return schema
 

--- a/ESSArch_Core/fixity/validation/tests/test_xml_schema_validator.py
+++ b/ESSArch_Core/fixity/validation/tests/test_xml_schema_validator.py
@@ -4,6 +4,7 @@ import tempfile
 from unittest import mock
 
 from django.test import TestCase
+from lxml import etree
 from lxml.etree import DocumentInvalid
 
 from ESSArch_Core.fixity.models import Validation
@@ -25,6 +26,154 @@ def create_mocked_error_log(line_number, error_msg):
 
 
 class XMLSchemaValidatorTests(TestCase):
+    def setUp(self):
+        self.datadir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.datadir)
+
+        try:
+            os.makedirs(self.datadir)
+        except OSError as e:
+            if e.errno != 17:
+                raise
+
+    def create_schema_file(self, path):
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:complexType name="itemtype">
+              <xs:sequence>
+                <xs:element name="title" type="xs:string"/>
+                <xs:element name="price" type="xs:decimal"/>
+              </xs:sequence>
+            </xs:complexType>
+
+            <xs:element name="item" type="itemtype"/>
+        </xs:schema>
+        """
+        path = os.path.join(self.datadir, path)
+
+        with open(path, 'w') as f:
+            f.write(content)
+
+        return path
+
+    def create_schema_file_with_import(self, path):
+        content = """<?xml version="1.0" encoding="UTF-8"?>
+        <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:import namespace="http://www.loc.gov/METS/"
+                       schemaLocation="https://www.loc.gov/standards/mets/mets.xsd"/>
+        </xs:schema>
+        """
+        path = os.path.join(self.datadir, path)
+
+        with open(path, 'w') as f:
+            f.write(content)
+
+        return path
+
+    def create_xml(self, xml_file_name):
+        xml_file_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <item>
+            <title>good</title>
+            <price>12.3</price>
+        </item>
+        """
+
+        xml_file_path = os.path.join(self.datadir, xml_file_name)
+
+        with open(xml_file_path, 'w') as f:
+            f.write(xml_file_content)
+
+        return xml_file_path
+
+    def create_bad_xml(self, xml_file_name):
+        xml_file_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <item>
+            <title>bad</title>
+            <price>foo</price>
+        </item>
+        """
+
+        xml_file_path = os.path.join(self.datadir, xml_file_name)
+
+        with open(xml_file_path, 'w') as f:
+            f.write(xml_file_content)
+
+        return xml_file_path
+
+    def test_validate_schema_against_valid_file(self):
+        schema_file_name = "schema.xsd"
+        schema_file_path = self.create_schema_file(schema_file_name)
+        xml_file_path = self.create_xml("xml_file.xml")
+
+        validator = XMLSchemaValidator(
+            context=schema_file_path,
+            options={'rootdir': self.datadir},
+        )
+        validator.validate(xml_file_path)
+
+    def test_validate_schema_against_bad_file(self):
+        schema_file_name = "schema.xsd"
+        schema_file_path = self.create_schema_file(schema_file_name)
+        xml_file_path = self.create_bad_xml("bad_xml_file.xml")
+
+        validator = XMLSchemaValidator(
+            context=schema_file_path,
+            options={'rootdir': self.datadir},
+        )
+
+        expected_error_message = "Element 'price': 'foo' is not a valid value of the atomic type 'xs:decimal'"
+
+        with self.assertRaisesRegexp(DocumentInvalid, expected_error_message):
+            validator.validate(xml_file_path)
+
+    def test_validate_with_imported_schema(self):
+        schema_file_name = "schema.xsd"
+        schema_file_path = self.create_schema_file_with_import(schema_file_name)
+        xml_file_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+            <mets:metsHdr/>
+            <mets:structMap>
+                <mets:div/>
+            </mets:structMap>
+        </mets:mets>
+        """
+
+        xml_file_path = os.path.join(self.datadir, 'test.xml')
+        with open(xml_file_path, 'w') as f:
+            f.write(xml_file_content)
+
+        validator = XMLSchemaValidator(
+            context=schema_file_path,
+            options={'rootdir': self.datadir},
+        )
+        validator.validate(xml_file_path)
+
+        bad_xml_file_content = """<?xml version="1.0" encoding="UTF-8"?>
+        <mets:mets xmlns:mets="http://www.loc.gov/METS/"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:xlink="http://www.w3.org/1999/xlink">
+            <mets:metsHdr>
+                this is incorrect
+            </mets:metsHdr>
+            <mets:structMap>
+                <mets:div/>
+            </mets:structMap>
+        </mets:mets>
+        """
+
+        with open(xml_file_path, 'w') as f:
+            f.write(bad_xml_file_content)
+
+        expected_error_message = "Character content other than whitespace"
+        with self.assertRaisesRegexp(DocumentInvalid, expected_error_message):
+            validator.validate(xml_file_path)
+
+        # ensure that the schema has only been modified in memory and not the file
+        schema_doc = etree.parse(schema_file_path)
+        schemaLocation = schema_doc.xpath('//*[local-name()="import"]/@schemaLocation')[0]
+        self.assertEqual(schemaLocation, "https://www.loc.gov/standards/mets/mets.xsd")
 
     @mock.patch("ESSArch_Core.fixity.validation.backends.xml.validate_against_schema")
     def test_when_documentInvalid_raised_create_validation_objects(self, validate_against_schema):

--- a/ESSArch_Core/ip/utils.py
+++ b/ESSArch_Core/ip/utils.py
@@ -2,6 +2,7 @@ import errno
 import os
 
 import requests
+from django.conf import settings
 from lxml import etree
 from requests import RequestException
 from tenacity import (
@@ -239,7 +240,10 @@ def download_schemas(ip, logger, verify):
 
 @retry(retry=retry_if_exception_type(RequestException), reraise=True, stop=stop_after_attempt(5),
        wait=wait_fixed(60))
-def download_schema(dirname, logger, schema, verify):
+def download_schema(dirname, logger, schema, verify=None):
+    if verify is None:
+        verify = settings.REQUESTS_VERIFY
+
     dst = os.path.join(dirname, os.path.basename(schema))
     logger.info('Downloading schema from {} to {}'.format(schema, dst))
     try:
@@ -262,3 +266,5 @@ def download_schema(dirname, logger, schema, verify):
         raise
     else:
         logger.info('Downloaded schema to {}'.format(dst))
+
+    return dst

--- a/ESSArch_Core/tests/test_util.py
+++ b/ESSArch_Core/tests/test_util.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 from django.core.files.base import ContentFile
 from django.http.response import FileResponse
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from lxml import etree, objectify
 from rest_framework.exceptions import NotFound, ValidationError
 
@@ -128,7 +128,7 @@ class FlattenTest(TestCase):
         self.assertEqual(result_list, flatten(my_list))
 
 
-class GetSchemasTest(TestCase):
+class GetSchemasTest(SimpleTestCase):
 
     def setUp(self):
         self.datadir = tempfile.mkdtemp()
@@ -159,11 +159,11 @@ class GetSchemasTest(TestCase):
         doc = etree.parse(filename, parser=parser)
 
         schema = getSchemas(doc=doc)
-        self.assertTrue(type(schema) is etree.XMLSchema)
+        self.assertTrue(type(schema) is etree._Element)
 
     def test_get_schema_from_file(self):
         schema = getSchemas(filename=self.get_simple_valid_xml())
-        self.assertTrue(type(schema) is etree.XMLSchema)
+        self.assertTrue(type(schema) is etree._Element)
 
     def test_get_schema_with_no_argument_should_throw_exception(self):
         with self.assertRaisesRegexp(AttributeError, "'NoneType' object has no attribute 'getroot'"):

--- a/ESSArch_Core/util.py
+++ b/ESSArch_Core/util.py
@@ -238,7 +238,7 @@ def getSchemas(doc=None, filename=None):
                 "schemaLocation": loc
             })
 
-    return etree.XMLSchema(root)
+    return root
 
 
 def move_schema_locations_to_root(tree=None, filename=None):


### PR DESCRIPTION
libxml2 which lxml uses, does currently not support schemas which imports external schemas using https.

To fix this we download the required schemas and update the import elements to instead point to the local copies. The modification is only done in memory so that the schema files are not changed and the local copies are deleted when the validation is finished.