### PR TITLE
Fix getSchemas when working with multiple schemas in schemaLocation

### DIFF
--- a/ESSArch_Core/util.py
+++ b/ESSArch_Core/util.py
@@ -231,7 +231,7 @@ def getSchemas(doc=None, filename=None):
     schema_locations = set(doc.xpath("//*/@xsi:schemaLocation", namespaces={'xsi': xsi_NS}))
     for schema_location in schema_locations:
         ns_locs = schema_location.split()
-        for ns, loc in zip(ns_locs[:-1], ns_locs[1:]):
+        for ns, loc in zip(ns_locs[::2], ns_locs[1::2]):
             res.append([ns, loc])
             etree.SubElement(root, xsd_NS + "import", attrib={
                 "namespace": ns,


### PR DESCRIPTION
### schemaLocation

```
http://www.loc.gov/METS/ http://xml.essarch.org/METS/version11/ESSPackageMETS.xsd ExtensionMETS http://xml.ra.se/e-arkiv/METS/version11/CSPackageExtensionMETS.xsd
```

### Before

```xml
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
  <xsd:import namespace="http://www.loc.gov/METS/" schemaLocation="http://xml.essarch.org/METS/version11/ESSPackageMETS.xsd"/>
  <xsd:import namespace="http://xml.essarch.org/METS/version11/ESSPackageMETS.xsd" schemaLocation="ExtensionMETS"/>
  <xsd:import namespace="ExtensionMETS" schemaLocation="http://xml.ra.se/e-arkiv/METS/version11/CSPackageExtensionMETS.xsd"/>
</xsd:schema>
```


### After

```xml
<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
  <xsd:import namespace="http://www.loc.gov/METS/" schemaLocation="http://xml.essarch.org/METS/version11/ESSPackageMETS.xsd"/>
  <xsd:import namespace="ExtensionMETS" schemaLocation="http://xml.ra.se/e-arkiv/METS/version11/CSPackageExtensionMETS.xsd"/>
</xsd:schema>
```