### PR TITLE
Parse and store SIP mets data in AIP profile in ReceiveSIP

### DIFF
--- a/ESSArch_Core/ip/models.py
+++ b/ESSArch_Core/ip/models.py
@@ -23,7 +23,6 @@
 """
 
 import errno
-import io
 import logging
 import math
 import os
@@ -106,6 +105,7 @@ from ESSArch_Core.util import (
     get_tree_size_and_count,
     in_directory,
     normalize_path,
+    open_file,
     timestamp_to_datetime,
 )
 from ESSArch_Core.WorkflowEngine.util import create_workflow
@@ -1796,28 +1796,10 @@ class InformationPackage(models.Model):
             if os.path.join(os.path.dirname(self.object_path), path) == xmlfile:
                 return open(xmlfile, *args)
 
-            try:
-                with tarfile.open(self.object_path) as tar:
-                    try:
-                        f = tar.extractfile(path)
-                    except KeyError:
-                        full_path = normalize_path(os.path.join(self.object_identifier_value, path))
-                        f = tar.extractfile(full_path)
-                    return io.BytesIO(f.read())
-            except tarfile.ReadError:
-                logger.debug('Invalid tar file, trying zipfile instead')
-                try:
-                    with zipfile.ZipFile(self.object_path) as zipf:
-                        try:
-                            f = zipf.open(path)
-                        except KeyError:
-                            full_path = normalize_path(os.path.join(self.object_identifier_value, path))
-                            f = zipf.open(full_path)
-                        return io.BytesIO(f.read())
-                except zipfile.BadZipfile:
-                    logger.debug('Invalid zip file')
-            except KeyError:
-                raise OSError(errno.ENOENT, os.strerror(errno.ENOENT), os.path.join(self.object_path, path))
+            return open_file(
+                path, *args, container=self.object_path,
+                container_prefix=self.object_identifier_value, **kwargs
+            )
 
         return open(os.path.join(self.object_path, path), *args, **kwargs)
 

--- a/ESSArch_Core/ip/tests/test_models.py
+++ b/ESSArch_Core/ip/tests/test_models.py
@@ -358,7 +358,7 @@ class InformationPackageOpenFileTests(TestCase):
             os.makedirs(dirname)
         fname = os.path.join(self.textdir, '%s' % filename)
         with open(fname, 'w') as f:
-            f.write("I'm a mets_xml")
+            f.write("this is a mets")
 
     def create_archive_file(self, archive_format):
         self.create_files()
@@ -413,41 +413,32 @@ class InformationPackageOpenFileTests(TestCase):
 
         mock_open.assert_called_once_with(path_to_mets_xml)
 
-    @mock.patch('ESSArch_Core.ip.models.io')
-    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_tar(self, mocked_io):
+    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_tar(self):
         self.create_mets_xml_file("mets.xml")
         archive_file = self.create_archive_file('tar')
         self.ip.object_path = archive_file
         self.ip.object_identifier_value = "identifier_value_that_does_not_match_mets_file_name"
         self.ip.save()
 
-        self.ip.open_file('./mets.xml')
+        self.assertEqual(self.ip.open_file('./mets.xml').read(), b'this is a mets')
 
-        mocked_io.BytesIO.assert_called_once()
-
-    @mock.patch('ESSArch_Core.ip.models.io')
-    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_tar_with_identifier(self, mocked_io):
+    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_tar_with_identifier(self):
         self.create_mets_xml_file("mets_folder/mets.xml")
         archive_file = self.create_archive_file('tar')
         self.ip.object_path = archive_file
         self.ip.object_identifier_value = "./mets_folder/"
         self.ip.save()
 
-        self.ip.open_file('mets.xml')
+        self.assertEqual(self.ip.open_file('mets.xml').read(), b'this is a mets')
 
-        mocked_io.BytesIO.assert_called_once()
-
-    @mock.patch('ESSArch_Core.ip.models.io')
-    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_zip(self, mocked_io):
+    def test_open_file_when_mets_path_not_set_then_read_mets_xml_from_zip(self):
         self.create_mets_xml_file("mets_folder/mets.xml")
         archive_file = self.create_archive_file('zip')
         self.ip.object_path = archive_file
         self.ip.object_identifier_value = "mets_folder/"
         self.ip.save()
 
-        self.ip.open_file('mets.xml')
-
-        mocked_io.BytesIO.assert_called_once()
+        self.assertEqual(self.ip.open_file('mets.xml').read(), b'this is a mets')
 
 
 class InformationPackageStepStateTests(TestCase):


### PR DESCRIPTION
METS files in SIPs might have data that can't be found in the database and that we want to reuse for the AIP