### PR TITLE
Add flake8 plugins "assertive" and "bugbear"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       stage: lint
       python: '3.7'
       before_install: skip
-      install: pip install flake8==3.7.1
+      install: pip install -r requirements/lint.txt
       before_script: skip
       script: flake8
       after_success: skip
@@ -36,7 +36,7 @@ matrix:
       stage: lint
       python: '3.7'
       before_install: skip
-      install: pip install isort==4.3.20
+      install: pip install -r requirements/lint.txt
       before_script: skip
       script: isort --recursive --check-only --diff ESSArch_Core
       after_success: skip

--- a/ESSArch_Core/WorkflowEngine/tests/test_steps.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_steps.py
@@ -58,7 +58,7 @@ class test_status(TestCase):
         depth = 5
         parent = self.step
 
-        for i in range(depth):
+        for _ in range(depth):
             parent = ProcessStep.objects.create(parent_step=parent)
 
         with self.assertNumQueries((6 * depth) + 2):
@@ -75,7 +75,7 @@ class test_status(TestCase):
         depth = 5
         parent = self.step
 
-        for i in range(depth):
+        for _ in range(depth):
             parent = ProcessStep.objects.create(parent_step=parent)
 
         self.step.status
@@ -410,7 +410,7 @@ class test_progress(TestCase):
         depth = 5
         parent = self.step
 
-        for i in range(depth):
+        for _ in range(depth):
             parent = ProcessStep.objects.create(parent_step=parent)
 
         with self.assertNumQueries((3 * (depth + 1)) - 1):
@@ -427,7 +427,7 @@ class test_progress(TestCase):
         depth = 5
         parent = self.step
 
-        for i in range(depth):
+        for _ in range(depth):
             parent = ProcessStep.objects.create(parent_step=parent)
 
         self.step.progress

--- a/ESSArch_Core/api/tests/test_serializers.py
+++ b/ESSArch_Core/api/tests/test_serializers.py
@@ -17,15 +17,15 @@ class DynamicModelSerializerTests(TestCase):
 
     def test_all_fields(self):
         data = InformationPackageSerializer(self.ip).data
-        self.assertTrue('label' in data)
-        self.assertTrue('object_identifier_value' in data)
+        self.assertIn('label', data)
+        self.assertIn('object_identifier_value', data)
 
     def test_selected_field(self):
         data = InformationPackageSerializer(self.ip, fields=['label']).data
-        self.assertTrue('label' in data)
-        self.assertFalse('object_identifier_value' in data)
+        self.assertIn('label', data)
+        self.assertNotIn('object_identifier_value', data)
 
     def test_omitted_field(self):
         data = InformationPackageSerializer(self.ip, omit=['label']).data
-        self.assertFalse('label' in data)
-        self.assertTrue('object_identifier_value' in data)
+        self.assertNotIn('label', data)
+        self.assertIn('object_identifier_value', data)

--- a/ESSArch_Core/auth/models.py
+++ b/ESSArch_Core/auth/models.py
@@ -203,13 +203,13 @@ class Group(GroupMixin):
             return DjangoUser.objects.filter(essauth_member__essauth_groups__=self)
 
     def add_object(self, obj):
-        if getattr(self, 'group_type') is None or getattr(self.group_type, 'codename') != 'organization':
+        if self.group_type is None or self.group_type.codename != 'organization':
             raise ValueError('objects cannot be added to non-organization groups')
         obj_content_type = ContentType.objects.get_for_model(obj)
         return GroupGenericObjects.objects.get_or_create(group=self, content_type=obj_content_type, object_id=obj.pk)
 
     def remove_object(self, obj):
-        if getattr(self, 'group_type') is None or getattr(self.group_type, 'codename') != 'organization':
+        if self.group_type is None or self.group_type.codename != 'organization':
             raise ValueError('objects cannot be added to non-organization groups')
         return GroupGenericObjects.objects.filter(group=self, content_object=obj).delete()
 

--- a/ESSArch_Core/auth/tests/test_signals.py
+++ b/ESSArch_Core/auth/tests/test_signals.py
@@ -39,4 +39,4 @@ class CurrentOrganizationTests(TestCase):
 
         group2.remove_member(self.member)
         self.user.user_profile.refresh_from_db()
-        self.assertEqual(self.user.user_profile.current_organization, None)
+        self.assertIsNone(self.user.user_profile.current_organization)

--- a/ESSArch_Core/essxml/Generator/tests/test_generate.py
+++ b/ESSArch_Core/essxml/Generator/tests/test_generate.py
@@ -721,7 +721,7 @@ class GenerateXMLTestCase(TestCase):
 
         num_of_files = 0
 
-        for root, dirs, files in walk(self.datadir):
+        for _root, _dirs, files in walk(self.datadir):
             for f in files:
                 file_element = tree.find(".//bar[@name='%s']" % f)
                 self.assertIsNotNone(file_element)
@@ -1242,7 +1242,7 @@ class GenerateXMLTestCase(TestCase):
 
         num_of_files = 0
 
-        for root, dirs, files in walk(self.datadir):
+        for root, _dirs, files in walk(self.datadir):
             for f in files:
                 file_element = tree.find(".//bar[@name='%s']" % f)
                 self.assertIsNotNone(file_element)
@@ -1370,7 +1370,7 @@ class GenerateXMLTestCase(TestCase):
         bars1 = tree1.findall('.//bar')
         bars2 = tree2.findall('.//bar')
 
-        self.assertTrue(len(bars2) == len(bars1) + 1)
+        self.assertEqual(len(bars2), len(bars1) + 1)
 
     def test_element_with_containsFiles_without_files(self):
         specification = {
@@ -1445,7 +1445,7 @@ class GenerateXMLTestCase(TestCase):
 
         num_of_files = 0
 
-        for root, dirs, files in walk(self.datadir):
+        for root, _dirs, files in walk(self.datadir):
             for f in files:
                 file_element = tree.find(".//{%s}bar[@name='%s']" % (nsmap['premis'], f))
                 self.assertIsNotNone(file_element)
@@ -1505,7 +1505,7 @@ class GenerateXMLTestCase(TestCase):
 
         num_of_files = 0
 
-        for root, dirs, files in walk(self.datadir):
+        for root, _dirs, files in walk(self.datadir):
             for f in files:
                 filepath = os.path.join(root, f)
                 relpath = normalize_path(os.path.relpath(filepath, self.datadir))
@@ -1726,7 +1726,7 @@ class GenerateXMLTestCase(TestCase):
         append_xml = '<appended>appended text</appended>'
 
         target = self.generator.find_element('foo')
-        for i in range(3):
+        for _ in range(3):
             self.generator.insert_from_xml_string(
                 target, append_xml,
             )
@@ -1758,7 +1758,7 @@ class GenerateXMLTestCase(TestCase):
         etree.ElementTree(append_el).write(append_xml, xml_declaration=True, encoding='UTF-8')
 
         target = self.generator.find_element('foo')
-        for i in range(3):
+        for _ in range(3):
             self.generator.insert_from_xml_file(
                 target, append_xml,
             )
@@ -1803,7 +1803,7 @@ class GenerateXMLTestCase(TestCase):
         }
 
         target = self.generator.find_element('foo')
-        for i in range(3):
+        for _ in range(3):
             self.generator.insert_from_specification(
                 target, append_specification, {},
             )
@@ -2124,7 +2124,7 @@ class GenerateXMLTestCase(TestCase):
         }
 
         target = self.generator.find_element('foo')
-        for i in range(3):
+        for _ in range(3):
             self.generator.insert_from_specification(
                 target, append_specification, {},
             )

--- a/ESSArch_Core/essxml/Generator/xmlGenerator.py
+++ b/ESSArch_Core/essxml/Generator/xmlGenerator.py
@@ -511,7 +511,7 @@ class XMLAttribute:
 def find_files_in_path_not_in_external_dirs(fid, path, external, algorithm, rootdir=""):
     files = []
     external = [e[1] for e in external]
-    for root, dirnames, filenames in walk(path):
+    for root, _dirnames, filenames in walk(path):
         for fname in filenames:
             filepath = os.path.join(root, fname)
             relpath = os.path.relpath(filepath, path)
@@ -597,7 +597,7 @@ class XMLGenerator:
         # See if any profile allows unknown file types.
         # If atleast one does allow it, we allow it for all profiles.
         allow_unknown_file_types = False
-        for idx, f in enumerate(self.toCreate):
+        for _idx, f in enumerate(self.toCreate):
             allow_unknown_file_types = f.get('data', {}).get('allow_unknown_file_types', False)
             if allow_unknown_file_types:
                 break

--- a/ESSArch_Core/essxml/Generator/xmlStructure.py
+++ b/ESSArch_Core/essxml/Generator/xmlStructure.py
@@ -37,11 +37,14 @@ class xmlElement:
     A class containing a complete XML element, a list of attributes and a list of children
     '''
 
-    def __init__(self, tagName='', nsmap={}, namespace=None):
+    def __init__(self, tagName='', nsmap=None, namespace=None):
         try:
             self.tagName = tagName.split("#")[0]
         except BaseException:
             self.tagName = tagName
+
+        if nsmap is None:
+            nsmap = {}
 
         self.children = []
         self.attributes = []

--- a/ESSArch_Core/essxml/ProfileMaker/views.py
+++ b/ESSArch_Core/essxml/ProfileMaker/views.py
@@ -76,7 +76,7 @@ def constructContent(text):
     return res
 
 
-def getTrail(elementTree, element, trail=[]):
+def getTrail(elementTree, element, trail=None):
     """
     Gets the path to the specified element via its parents.
 
@@ -98,6 +98,9 @@ def getTrail(elementTree, element, trail=[]):
         A list containing the ancestors of the specified element
     """
 
+    if trail is None:
+        trail = []
+
     parent = element.get('parent')
     trail.insert(0, element.get('name'))
 
@@ -107,7 +110,13 @@ def getTrail(elementTree, element, trail=[]):
         return trail
 
 
-def generateElement(elements, currentUuid, takenNames=[], containsFiles=False, namespace='', nsmap={}):
+def generateElement(elements, currentUuid, takenNames=None, containsFiles=False, namespace='', nsmap=None):
+    if takenNames is None:
+        takenNames = []
+
+    if nsmap is None:
+        nsmap = {}
+
     element = elements[currentUuid]
     el = OrderedDict()
     forms = []

--- a/ESSArch_Core/essxml/ProfileMaker/xsdtojson.py
+++ b/ESSArch_Core/essxml/ProfileMaker/xsdtojson.py
@@ -71,7 +71,7 @@ def getSuffix(tag):
     tag = tag.split(':')[-1]
 
 
-def analyze2(element, tree, usedTypes=[], minC=1, maxC=1, choise=-1):
+def analyze2(element, tree, usedTypes=None, minC=1, maxC=1, choise=-1):
     global choiseCount
     global elCount
     global complexTypes
@@ -79,6 +79,9 @@ def analyze2(element, tree, usedTypes=[], minC=1, maxC=1, choise=-1):
     global finishedGroups
     global attributesComplexTypes
     global elementTypes
+
+    if usedTypes is None:
+        usedTypes = []
 
     tag = printTag(element.tag)
     ref = element.get('ref')

--- a/ESSArch_Core/fixity/tests/test_format.py
+++ b/ESSArch_Core/fixity/tests/test_format.py
@@ -56,8 +56,8 @@ class FormatIdentifierMimeTypeTests(TestCase):
         fid.handle_matches('fullname', [], mock.ANY)
 
         self.assertEqual(fid.format_name, 'Unknown File Format')
-        self.assertEqual(fid.format_version, None)
-        self.assertEqual(fid.format_registry_key, None)
+        self.assertIsNone(fid.format_version)
+        self.assertIsNone(fid.format_registry_key)
 
     @mock.patch("ESSArch_Core.fixity.format.mimetypes.guess_type", return_value=(None, mock.ANY))
     def test_handle_matches_when_no_matches_and_unknown_types_not_allowed(self, mock_mimetypes_init):
@@ -73,6 +73,6 @@ class FormatIdentifierMimeTypeTests(TestCase):
 
         fid.handle_matches('fullname', dummy_matches, mock.ANY)
 
-        self.assertEqual(fid.format_name, None)
-        self.assertEqual(fid.format_version, None)
-        self.assertEqual(fid.format_registry_key, None)
+        self.assertIsNone(fid.format_name)
+        self.assertIsNone(fid.format_version)
+        self.assertIsNone(fid.format_registry_key)

--- a/ESSArch_Core/fixity/validation/__init__.py
+++ b/ESSArch_Core/fixity/validation/__init__.py
@@ -77,7 +77,7 @@ def _validate_directory(path, validators, task=None, ip=None, stop_at_failure=Tr
             if stop_at_failure:
                 raise
 
-    for root, dirs, files in walk(path):
+    for root, _dirs, files in walk(path):
         for f in files:
             _validate_file(
                 os.path.join(root, f),

--- a/ESSArch_Core/fixity/validation/backends/structure.py
+++ b/ESSArch_Core/fixity/validation/backends/structure.py
@@ -86,7 +86,7 @@ class StructureValidator(BaseValidator):
                 for nested_idx, nested_valid in enumerate(valid):
                     valid[nested_idx] = normalize_path(os.path.join(path, nested_valid).format(**self.data))
 
-        for root, dirs, files in walk(path):
+        for root, _dirs, files in walk(path):
             for f in files:
                 file_count += 1
                 if len(valid_paths):

--- a/ESSArch_Core/fixity/validation/backends/xml.py
+++ b/ESSArch_Core/fixity/validation/backends/xml.py
@@ -200,7 +200,7 @@ class DiffCheckValidator(BaseValidator):
         return delete_count
 
     def _validate_present_files(self, objs):
-        for present_hash, present_hash_files in self.present.items():
+        for _present_hash, present_hash_files in self.present.items():
             for f in present_hash_files:
                 self.added += 1
                 msg = '{f} is missing from {xml}'.format(f=f, xml=self.context)
@@ -215,7 +215,7 @@ class DiffCheckValidator(BaseValidator):
         logger.debug('Validating {path} against {xml}'.format(path=path, xml=xmlfile))
 
         if os.path.isdir(path):
-            for root, dirs, files in walk(path):
+            for root, _dirs, files in walk(path):
                 for f in files:
                     filepath = normalize_path(os.path.join(root, f))
                     if filepath in self.exclude or filepath == xmlfile:

--- a/ESSArch_Core/install/install_default_config.py
+++ b/ESSArch_Core/install/install_default_config.py
@@ -594,7 +594,7 @@ def installPipelines():
 
 
 def installSearchIndices():
-    for index_name, index_class in settings.ELASTICSEARCH_INDEXES['default'].items():
+    for _index_name, index_class in settings.ELASTICSEARCH_INDEXES['default'].items():
         doctype = locate(index_class)
         alias_migration.setup_index(doctype)
 

--- a/ESSArch_Core/ip/signals.py
+++ b/ESSArch_Core/ip/signals.py
@@ -26,7 +26,7 @@ def ip_post_delete(sender, instance, using, **kwargs):
     GroupGenericObjects.objects.filter(object_id=str(instance.pk), content_type=ip_content_type).delete()
 
     try:
-        if getattr(instance, 'aic') is not None and not instance.aic.information_packages.exists():
+        if instance.aic is not None and not instance.aic.information_packages.exists():
             # this was the last IP in the AIC, delete the AIC as well
             instance.aic.delete()
     except InformationPackage.DoesNotExist:

--- a/ESSArch_Core/ip/tests/test_ips.py
+++ b/ESSArch_Core/ip/tests/test_ips.py
@@ -1094,16 +1094,16 @@ class InformationPackageViewSetTestCase(TestCase):
         self.assertEqual(len(res.data), 2)
         self.assertEqual(res.data[0]['id'], str(aic.pk))
 
-        self.assertEqual(res.data[0]['information_packages'][0]['first_generation'], True)
-        self.assertEqual(res.data[0]['information_packages'][0]['last_generation'], False)
-        self.assertEqual(res.data[0]['information_packages'][1]['first_generation'], False)
-        self.assertEqual(res.data[0]['information_packages'][1]['last_generation'], True)
+        self.assertTrue(res.data[0]['information_packages'][0]['first_generation'])
+        self.assertFalse(res.data[0]['information_packages'][0]['last_generation'])
+        self.assertFalse(res.data[0]['information_packages'][1]['first_generation'])
+        self.assertTrue(res.data[0]['information_packages'][1]['last_generation'])
 
         self.assertEqual(len(res.data[1]['information_packages']), 2)
-        self.assertEqual(res.data[1]['information_packages'][0]['first_generation'], True)
-        self.assertEqual(res.data[1]['information_packages'][0]['last_generation'], False)
-        self.assertEqual(res.data[1]['information_packages'][1]['first_generation'], False)
-        self.assertEqual(res.data[1]['information_packages'][1]['last_generation'], False)
+        self.assertTrue(res.data[1]['information_packages'][0]['first_generation'])
+        self.assertFalse(res.data[1]['information_packages'][0]['last_generation'])
+        self.assertFalse(res.data[1]['information_packages'][1]['first_generation'])
+        self.assertFalse(res.data[1]['information_packages'][1]['last_generation'])
 
     def test_ip_view_type_aic_multiple_aips_different_states_filter_state(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)

--- a/ESSArch_Core/ip/tests/test_models.py
+++ b/ESSArch_Core/ip/tests/test_models.py
@@ -512,7 +512,7 @@ class InformationPackageStepStateTests(TestCase):
     def test_step_state_when_its_an_AIP_with_all_success_tasks_then_success(self):
         aip = InformationPackage.objects.create(package_type=InformationPackage.AIP)
 
-        for i in range(3):
+        for _ in range(3):
             ProcessTask.objects.create(information_package=aip, status=celery_state.SUCCESS)
 
         state = aip.step_state
@@ -557,7 +557,7 @@ class InformationPackageGetAgentTests(TestCase):
         ip.agents.add(agent)
         ip.save()
 
-        self.assertEqual(ip.get_agent("non existent role", "type_1"), None)
+        self.assertIsNone(ip.get_agent("non existent role", "type_1"))
 
     def test_get_agent_when_type_does_not_exists_should_return_None(self):
         agent = Agent.objects.create(role="role_1", type="type_1", name="name_1", code="code_1")
@@ -565,7 +565,7 @@ class InformationPackageGetAgentTests(TestCase):
         ip.agents.add(agent)
         ip.save()
 
-        self.assertEqual(ip.get_agent("role_1", "non existing type"), None)
+        self.assertIsNone(ip.get_agent("role_1", "non existing type"))
 
     def test_get_agent_when_exists_return_agent(self):
         agent = Agent.objects.create(role="role_1", type="type_1", name="name_1", code="code_1")
@@ -601,7 +601,7 @@ class InformationPackageIsLockedTests(TestCase):
 
     def test_is_locked_not_in_cache_should_return_False(self):
         ip = InformationPackage.objects.create()
-        self.assertEqual(ip.is_locked(), False)
+        self.assertFalse(ip.is_locked())
 
 
 class InformationPackageGetChecksumAlgorithmTests(TestCase):
@@ -655,14 +655,14 @@ class InformationPackageGetEmailRecipientTests(TestCase):
         ip = InformationPackage.objects.create()
         mock_profile_data.return_value = {}
 
-        self.assertEqual(ip.get_email_recipient(), None)
+        self.assertIsNone(ip.get_email_recipient())
 
     @mock.patch('ESSArch_Core.ip.models.InformationPackage.get_profile_data')
     def test_get_email_recipient_when_profile_data_is_None_return_None(self, mock_profile_data):
         ip = InformationPackage.objects.create()
         mock_profile_data.return_value = None
 
-        self.assertEqual(ip.get_email_recipient(), None)
+        self.assertIsNone(ip.get_email_recipient())
 
     @mock.patch('ESSArch_Core.ip.models.InformationPackage.get_profile_data')
     def test_get_email_recipient_get_from_profile_data(self, mock_profile_data):
@@ -715,21 +715,21 @@ class InformationPackageGenerationTests(TestCase):
     def test_is_first_generation_aic_is_None_should_return_True(self):
         aip = InformationPackage.objects.create(package_type=InformationPackage.AIP, generation=0)
 
-        self.assertEqual(aip.is_first_generation(), True)
+        self.assertTrue(aip.is_first_generation())
 
     def test_is_first_generation_aic_with_single_aip_should_return_True(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=0)
 
-        self.assertEqual(aip.is_first_generation(), True)
+        self.assertTrue(aip.is_first_generation())
 
     def test_is_first_generation_aic_with_multiple_aips(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip_1 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=42)
         aip_2 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=13)
 
-        self.assertEqual(aip_1.is_first_generation(), False)
-        self.assertEqual(aip_2.is_first_generation(), True)
+        self.assertFalse(aip_1.is_first_generation())
+        self.assertTrue(aip_2.is_first_generation())
 
     def test_is_first_generation_aic_with_multiple_aips_when_workarea_read_only_is_False_should_be_filtered(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
@@ -737,34 +737,34 @@ class InformationPackageGenerationTests(TestCase):
         aip_2 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=13)
         Workarea.objects.create(ip=aip_2, read_only=False, user=self.user)
 
-        self.assertEqual(aip_1.is_first_generation(), True)
-        self.assertEqual(aip_2.is_first_generation(), False)
+        self.assertTrue(aip_1.is_first_generation())
+        self.assertFalse(aip_2.is_first_generation())
 
     def test_is_first_generation_aic_when_workarea_read_only_is_False_should_be_filtered(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=42)
         Workarea.objects.create(ip=aip, read_only=False, user=self.user)
 
-        self.assertEqual(aip.is_first_generation(), False)
+        self.assertFalse(aip.is_first_generation())
 
     def test_is_last_generation_aic_is_None_should_return_True(self):
         aip = InformationPackage.objects.create(package_type=InformationPackage.AIP, generation=0)
 
-        self.assertEqual(aip.is_last_generation(), True)
+        self.assertTrue(aip.is_last_generation())
 
     def test_is_last_generation_aic_with_single_aip_should_return_True(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=0)
 
-        self.assertEqual(aip.is_last_generation(), True)
+        self.assertTrue(aip.is_last_generation())
 
     def test_is_last_generation_aic_with_multiple_aips(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip_1 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=42)
         aip_2 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=13)
 
-        self.assertEqual(aip_1.is_last_generation(), True)
-        self.assertEqual(aip_2.is_last_generation(), False)
+        self.assertTrue(aip_1.is_last_generation())
+        self.assertFalse(aip_2.is_last_generation())
 
     def test_is_last_generation_aic_with_multiple_aips_when_workarea_read_only_is_False_should_be_filtered(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
@@ -772,15 +772,15 @@ class InformationPackageGenerationTests(TestCase):
         aip_2 = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=13)
         Workarea.objects.create(ip=aip_1, read_only=False, user=self.user)
 
-        self.assertEqual(aip_1.is_last_generation(), False)
-        self.assertEqual(aip_2.is_last_generation(), True)
+        self.assertFalse(aip_1.is_last_generation())
+        self.assertTrue(aip_2.is_last_generation())
 
     def test_is_last_generation_aic_when_workarea_read_only_is_False_should_be_filtered(self):
         aic = InformationPackage.objects.create(package_type=InformationPackage.AIC)
         aip = InformationPackage.objects.create(aic=aic, package_type=InformationPackage.AIP, generation=42)
         Workarea.objects.create(ip=aip, read_only=False, user=self.user)
 
-        self.assertEqual(aip.is_last_generation(), False)
+        self.assertFalse(aip.is_last_generation())
 
 
 class InformationPackageCreatePreservationWorkflowTests(TestCase):

--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -728,7 +728,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
             try:
                 profile_ip.clean()
             except ValidationError as e:
-                raise exceptions.ParseError('%s: %s' % (profile_ip.profile.name, e.message))
+                raise exceptions.ParseError('%s: %s' % (profile_ip.profile.name, str(e)))
 
             profile_ip.LockedBy = request.user
             profile_ip.save()

--- a/ESSArch_Core/maintenance/models.py
+++ b/ESSArch_Core/maintenance/models.py
@@ -36,7 +36,7 @@ def find_all_files(datadir, ip, pattern):
     found_files = []
     for path in iglob(datadir + '/' + pattern):
         if os.path.isdir(path):
-            for root, dirs, files in walk(path):
+            for root, _dirs, files in walk(path):
                 rel = os.path.relpath(root, datadir)
 
                 for f in files:
@@ -164,7 +164,7 @@ class AppraisalRule(MaintenanceRule):
                 for pattern in self.specification:
                     found_files.extend(find_all_files(datadir, ip, pattern))
             else:
-                for root, dirs, files in walk(datadir):
+                for root, _dirs, files in walk(datadir):
                     rel = os.path.relpath(root, datadir)
 
                     for f in files:
@@ -209,7 +209,7 @@ class AppraisalJob(MaintenanceJob):
 
             if not self.rule.specification:
                 # register all files
-                for root, dirs, files in walk(srcdir):
+                for root, _dirs, files in walk(srcdir):
                     rel = os.path.relpath(root, srcdir)
 
                     for f in files:
@@ -243,7 +243,7 @@ class AppraisalJob(MaintenanceJob):
                 for pattern in self.rule.specification:
                     for path in iglob(dstdir + '/' + pattern):
                         if os.path.isdir(path):
-                            for root, dirs, files in walk(path):
+                            for root, _dirs, files in walk(path):
                                 rel = os.path.relpath(root, dstdir)
 
                                 for f in files:
@@ -307,7 +307,7 @@ class ConversionRule(MaintenanceRule):
         for ip in ips:
             storage_target = ip.policy.cache_storage.enabled_target.target
             datadir = os.path.join(storage_target, ip.object_identifier_value)
-            for pattern, spec in self.specification.items():
+            for pattern, _spec in self.specification.items():
                 found_files.extend(find_all_files(datadir, ip, pattern))
         return found_files
 
@@ -361,7 +361,7 @@ class ConversionJob(MaintenanceJob):
 
                 for path in iglob(dstdir + '/' + pattern):
                     if os.path.isdir(path):
-                        for root, dirs, files in walk(path):
+                        for root, _dirs, files in walk(path):
                             rel = os.path.relpath(root, dstdir)
 
                             for f in files:

--- a/ESSArch_Core/maintenance/tests/test_models.py
+++ b/ESSArch_Core/maintenance/tests/test_models.py
@@ -97,9 +97,9 @@ class MaintenanceJobMarkAsCompleteTests(TestCase):
         conversion_job = ConversionJob.objects.create()
 
         self.assertEqual(appraisal_job.status, celery_states.PENDING)
-        self.assertEqual(appraisal_job.end_date, None)
+        self.assertIsNone(appraisal_job.end_date)
         self.assertEqual(conversion_job.status, celery_states.PENDING)
-        self.assertEqual(conversion_job.end_date, None)
+        self.assertIsNone(conversion_job.end_date)
 
         appraisal_job._mark_as_complete()
         conversion_job._mark_as_complete()
@@ -122,9 +122,9 @@ class MaintenanceJobMarkAsCompleteTests(TestCase):
         conversion_job = ConversionJob.objects.create()
 
         self.assertEqual(appraisal_job.status, celery_states.PENDING)
-        self.assertEqual(appraisal_job.end_date, None)
+        self.assertIsNone(appraisal_job.end_date)
         self.assertEqual(conversion_job.status, celery_states.PENDING)
-        self.assertEqual(conversion_job.end_date, None)
+        self.assertIsNone(conversion_job.end_date)
 
         with self.assertRaises(Exception):
             appraisal_job._mark_as_complete()
@@ -323,9 +323,9 @@ class MaintenanceJobRunTests(TestCase):
         self.conversion_job.refresh_from_db()
 
         self.assertEqual(self.appraisal_job.status, celery_states.STARTED)
-        self.assertEqual(self.appraisal_job.end_date, None)
+        self.assertIsNone(self.appraisal_job.end_date)
         self.assertEqual(self.conversion_job.status, celery_states.STARTED)
-        self.assertEqual(self.conversion_job.end_date, None)
+        self.assertIsNone(self.conversion_job.end_date)
 
 
 class FindAllFilesTests(TestCase):

--- a/ESSArch_Core/search/importers/tests/test_earderms.py
+++ b/ESSArch_Core/search/importers/tests/test_earderms.py
@@ -327,7 +327,7 @@ class ParseExtraIdTests(TestCase):
         root = get_xml_root_from_string(xml_string)
         data = self.importer.parse_extra_id(root)
 
-        self.assertEqual(data, None)
+        self.assertIsNone(data)
 
     def test_parse_extra_id_with_text_should_get_type_and_id(self):
         xml_string = '''<root ExtraIDTyp='some id type'>some_id_text</root>'''
@@ -989,7 +989,7 @@ class ParseActTests(TestCase):
         self.assertEqual(root.xpath("*[local-name()='Gallring']"), [])
 
         tag_version = self.importer.parse_act(root, self.errand, self.ip)
-        self.assertEqual(tag_version.custom_fields.get('gallring'), None)
+        self.assertIsNone(tag_version.custom_fields.get('gallring'))
 
     def test_parse_act_when_ExtraID_tag_has_no_text_then_should_not_add_to_data(self):
         root = self.get_arkivobjekt_handling()
@@ -997,7 +997,7 @@ class ParseActTests(TestCase):
         # Remove text for 'ExtraID' tag
         root.xpath("*[local-name()='ExtraID']")[0].clear()
         # Make sure 'ExtraID' text is cleared
-        self.assertEqual(root.xpath("*[local-name()='ExtraID']")[0].text, None)
+        self.assertIsNone(root.xpath("*[local-name()='ExtraID']")[0].text)
 
         tag_version = self.importer.parse_act(root, self.errand, self.ip)
 

--- a/ESSArch_Core/storage/backends/s3.py
+++ b/ESSArch_Core/storage/backends/s3.py
@@ -84,7 +84,7 @@ class S3StorageBackend(BaseStorageBackend):
                     raise
 
                 parent_dir = os.path.dirname(f)
-                for root, dirs, files in walk(f):
+                for root, _dirs, files in walk(f):
                     for fi in files:
                         srcf = os.path.join(root, fi)
                         dstf = os.path.relpath(os.path.join(root, fi), parent_dir)

--- a/ESSArch_Core/storage/backends/tests/test_disk.py
+++ b/ESSArch_Core/storage/backends/tests/test_disk.py
@@ -269,7 +269,7 @@ class DiskStorageBackendTests(TestCase):
         os.makedirs(dst)
         self.assertTrue(os.path.exists(dst))
 
-        self.assertTrue(os.listdir(dst) == [])
+        self.assertEqual(os.listdir(dst), [])
 
         disk_storage_backend._extract(mock_storage_obj, dst)
 

--- a/ESSArch_Core/storage/tape.py
+++ b/ESSArch_Core/storage/tape.py
@@ -190,7 +190,7 @@ def tape_empty(drive):
         logger.exception('Unknown error while opening tape in {drive}'.format(drive=drive))
         raise
     except tarfile.ReadError as e:
-        if e.message == 'empty file':
+        if str(e) == 'empty file':
             logger.debug('Empty file in tape in {drive}, tape is empty'.format(drive=drive))
             rewind_tape(drive)
             return True

--- a/ESSArch_Core/storage/tests/test_models.py
+++ b/ESSArch_Core/storage/tests/test_models.py
@@ -71,7 +71,7 @@ class StorageTargetCreateStorageMediumTests(TestCase):
 
         self.assertEqual(medium.location, 'dummy_medium_location')
         self.assertEqual(medium.agent, 'dummy_agent_id')
-        self.assertEqual(medium.tape_slot, None)
+        self.assertIsNone(medium.tape_slot)
         self.assertEqual(medium.medium_id, storage_target_name)
 
     def test_when_no_storage_medium_exists_should_create_new_StorageMedium_for_TAPE(self):
@@ -146,7 +146,7 @@ class StorageTargetGetOrCreateStorageMediumTests(TestCase):
         medium, created = storage_target.get_or_create_storage_medium(None)
 
         self.assertEqual(medium, "Dummy_medium")
-        self.assertEqual(created, True)
+        self.assertTrue(created)
 
     @mock.patch('ESSArch_Core.storage.models.StorageTarget._create_storage_medium')
     def test_when_called_with_no_params_and_no_StorageMedium_exists_then_create(self, mock_create_storage_medium):
@@ -160,7 +160,7 @@ class StorageTargetGetOrCreateStorageMediumTests(TestCase):
         medium, created = storage_target.get_or_create_storage_medium()
 
         self.assertEqual(medium, "Dummy_medium")
-        self.assertEqual(created, True)
+        self.assertTrue(created)
 
     def test_when_qs_is_None_but_StorageMedium_exists_and_found_then_return_medium_from_DB(self):
         storage_target = StorageTarget.objects.create(
@@ -173,7 +173,7 @@ class StorageTargetGetOrCreateStorageMediumTests(TestCase):
         medium, created = storage_target.get_or_create_storage_medium()
 
         self.assertEqual(medium, storage_medium)
-        self.assertEqual(created, False)
+        self.assertFalse(created)
 
     @mock.patch('ESSArch_Core.storage.models.StorageTarget._create_storage_medium')
     def test_when_qs_is_None_and_StorageMedium_is_not_found_then_return_medium_from_DB(self, mock_create_sm):
@@ -192,7 +192,7 @@ class StorageTargetGetOrCreateStorageMediumTests(TestCase):
         medium, created = storage_target.get_or_create_storage_medium()
 
         self.assertEqual(medium, "dummy_medium")
-        self.assertEqual(created, True)
+        self.assertTrue(created)
 
     def test_when_qs_is_passed_as_parameter_then_return_medium_from_DB(self):
         storage_target = StorageTarget.objects.create(
@@ -206,7 +206,7 @@ class StorageTargetGetOrCreateStorageMediumTests(TestCase):
         medium, created = storage_target.get_or_create_storage_medium(qs)
 
         self.assertEqual(medium, storage_medium)
-        self.assertEqual(created, False)
+        self.assertFalse(created)
 
 
 class StorageTargetGetStorageBackendTests(TestCase):

--- a/ESSArch_Core/storage/tests/test_tape.py
+++ b/ESSArch_Core/storage/tests/test_tape.py
@@ -156,7 +156,7 @@ class TapeTests(TestCase):
         attrs = {'communicate.return_value': ('the drive is ONLINE now', 'error'), 'returncode': 0}
         mock_popen.return_value.configure_mock(**attrs)
 
-        self.assertEqual(is_tape_drive_online("device_to_verify"), True)
+        self.assertTrue(is_tape_drive_online("device_to_verify"))
 
         cmd = 'mt -f device_to_verify status'
         mock_popen.assert_called_once_with(cmd, shell=True, stderr=PIPE, stdout=PIPE, universal_newlines=True)
@@ -166,7 +166,7 @@ class TapeTests(TestCase):
         attrs = {'communicate.return_value': ('the drive is offline', 'error'), 'returncode': 0}
         mock_popen.return_value.configure_mock(**attrs)
 
-        self.assertEqual(is_tape_drive_online("device_to_verify"), False)
+        self.assertFalse(is_tape_drive_online("device_to_verify"))
 
         cmd = 'mt -f device_to_verify status'
         mock_popen.assert_called_once_with(cmd, shell=True, stderr=PIPE, stdout=PIPE, universal_newlines=True)
@@ -206,7 +206,7 @@ class TapeTests(TestCase):
         mocked_tar = mock.Mock()
         mock_tarfile.open.return_value = mocked_tar
 
-        self.assertEqual(tape_empty("some_drive"), False)
+        self.assertFalse(tape_empty("some_drive"))
 
         mock_tarfile.open.assert_called_once()
         mocked_tar.close.assert_called_once()
@@ -219,7 +219,7 @@ class TapeTests(TestCase):
         exception.errno = errno.EIO
         mock_tarfile.open.side_effect = exception
 
-        self.assertEqual(tape_empty("some_drive"), True)
+        self.assertTrue(tape_empty("some_drive"))
 
         mock_tarfile.open.assert_called_once()
         mock_rewind_tape.assert_called_once_with("some_drive")
@@ -239,11 +239,10 @@ class TapeTests(TestCase):
     @mock.patch('ESSArch_Core.storage.tape.tarfile.open')
     @mock.patch('ESSArch_Core.storage.tape.rewind_tape')
     def test_tape_empty_when_tarfile_ReadError_with_msg_then_drive_is_empty(self, mock_rewind_tape, mock_tarfile_open):
-        exception = tarfile.ReadError()
-        exception.message = 'empty file'
+        exception = tarfile.ReadError('empty file')
         mock_tarfile_open.side_effect = exception
 
-        self.assertEqual(tape_empty("some_drive"), True)
+        self.assertTrue(tape_empty("some_drive"))
 
         mock_tarfile_open.assert_called_once()
         mock_rewind_tape.assert_called_once_with("some_drive")
@@ -406,21 +405,21 @@ class TapeLabelTest(TestCase):
         mock_medium = self.get_mocked_medium("code id", current_time, 103, 512, 325)
         xml_content = self.get_valid_xml_with_date("code id", current_time, 103, 512, 325)
 
-        self.assertEqual(verify_tape_label(mock_medium, xml_content.encode()), True)
+        self.assertTrue(verify_tape_label(mock_medium, xml_content.encode()))
 
     def test_verify_tape_label_bad_xml_should_return_False(self):
         current_time = timezone.now()
         mock_medium = self.get_mocked_medium("code id", current_time, 103, 512, 325)
         xml_content = """badXML"""
 
-        self.assertEqual(verify_tape_label(mock_medium, xml_content.encode()), False)
+        self.assertFalse(verify_tape_label(mock_medium, xml_content.encode()))
 
     def test_verify_tape_label_id_differs_should_return_False(self):
         current_time = timezone.now()
         mock_medium = self.get_mocked_medium("code id", current_time, 103, 512, 325)
         xml_content = self.get_valid_xml_with_date("some other id", current_time, 103, 512, 325)
 
-        self.assertEqual(verify_tape_label(mock_medium, xml_content.encode()), False)
+        self.assertFalse(verify_tape_label(mock_medium, xml_content.encode()))
 
     def test_verify_tape_label_tape_tag_missing_should_return_False(self):
         current_time = timezone.now()
@@ -432,4 +431,4 @@ class TapeLabelTest(TestCase):
 </label>
 """
 
-        self.assertEqual(verify_tape_label(mock_medium, xml_content.encode()), False)
+        self.assertFalse(verify_tape_label(mock_medium, xml_content.encode()))

--- a/ESSArch_Core/tags/search.py
+++ b/ESSArch_Core/tags/search.py
@@ -195,7 +195,7 @@ class ComponentSearch(FacetedSearch):
             for field in self.fields:
                 if '__' in field:
                     paths = field.split('__')
-                    for idx, path in enumerate(paths):
+                    for idx, _path in enumerate(paths):
                         if idx == 0:
                             continue
 

--- a/ESSArch_Core/tasks.py
+++ b/ESSArch_Core/tasks.py
@@ -151,7 +151,7 @@ class GenerateXML(DBTask):
         if filesToCreate is None:
             filesToCreate = {}
 
-        for f, template in filesToCreate.items():
+        for f, _template in filesToCreate.items():
             try:
                 os.remove(f)
             except OSError as e:
@@ -362,7 +362,7 @@ class ValidateWorkarea(DBTask):
                 passed=False, required=True
             ).values_list('validator', flat=True)
 
-            for k, v in workarea.successfully_validated.items():
+            for k, _v in workarea.successfully_validated.items():
                 class_name = validation.AVAILABLE_VALIDATORS[k].split('.')[-1]
                 workarea.successfully_validated[k] = class_name not in failed_validators
 
@@ -815,7 +815,7 @@ class ConvertFile(DBTask):
                     os.remove(path)
             return
 
-        for root, dirs, filenames in walk(path):
+        for root, _dirs, filenames in walk(path):
             for fname in filenames:
                 filepath = os.path.join(root, fname)
                 try:

--- a/ESSArch_Core/tests/test_tasks_util.py
+++ b/ESSArch_Core/tests/test_tasks_util.py
@@ -61,8 +61,8 @@ class TapeMountOrUnmountTests(TestCase):
         tape_drive.refresh_from_db()
 
         mock_unmount_tape.assert_called_once_with("robot_device", 12, 2)
-        self.assertEqual(tape_drive.locked, False)
-        self.assertEqual(storage_medium.tape_drive, None)
+        self.assertFalse(tape_drive.locked)
+        self.assertIsNone(storage_medium.tape_drive)
         self.assertTrue(before <= tape_drive.last_change <= after)
         self.assertEqual(res, "dummy_output")
 
@@ -83,9 +83,9 @@ class TapeMountOrUnmountTests(TestCase):
         tape_drive.refresh_from_db()
 
         mock_unmount_tape.assert_called_once_with("robot_device", 12, 2)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(storage_medium.status, 100)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(tape_drive.status, 100)
         self.assertEqual(storage_medium.tape_slot.status, 100)
 
@@ -131,9 +131,9 @@ class TapeMountOrUnmountTests(TestCase):
         tape_drive.refresh_from_db()
 
         mock_mount_tape.assert_called_once_with("robot_device", 12, 2)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(storage_medium.status, 100)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(tape_drive.status, 100)
         self.assertEqual(storage_medium.tape_slot.status, 100)
 
@@ -154,9 +154,9 @@ class TapeMountOrUnmountTests(TestCase):
         tape_drive.refresh_from_db()
 
         mock_mount_tape.assert_called_once_with("robot_device", 12, 2)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(storage_medium.status, 100)
-        self.assertEqual(tape_drive.locked, False)
+        self.assertFalse(tape_drive.locked)
         self.assertEqual(tape_drive.status, 100)
         self.assertEqual(storage_medium.tape_slot.status, 100)
 
@@ -179,7 +179,7 @@ class TapeMountOrUnmountTests(TestCase):
         mount_tape.assert_called_once_with("robot_device", 12, 2)
         wait_to_come_online.assert_called_once_with("unique_char", 121)
         self.assertEqual(tape_drive.num_of_mounts, 1)
-        self.assertEqual(tape_drive.locked, True)
+        self.assertTrue(tape_drive.locked)
         self.assertTrue(before <= tape_drive.last_change <= after)
         self.assertEqual(storage_medium.num_of_mounts, 1)
         self.assertEqual(storage_medium.tape_drive_id, tape_drive.pk)

--- a/ESSArch_Core/tests/test_util.py
+++ b/ESSArch_Core/tests/test_util.py
@@ -83,12 +83,12 @@ class GetValueFromPathTest(TestCase):
     def test_get_value_from_path_when_path_is_none(self):
         xml = self.get_simple_xml()
         root_xml = objectify.fromstring(xml)
-        self.assertEqual(get_value_from_path(root_xml, None), None)
+        self.assertIsNone(get_value_from_path(root_xml, None))
 
     def test_get_value_from_path_when_attribute_is_missing(self):
         xml = self.get_simple_xml()
         root_xml = objectify.fromstring(xml)
-        self.assertEqual(get_value_from_path(root_xml, "anmerkningar@non_existing_attr"), None)
+        self.assertIsNone(get_value_from_path(root_xml, "anmerkningar@non_existing_attr"))
 
 
 class GetFilesAndDirsTest(TestCase):
@@ -159,11 +159,11 @@ class GetSchemasTest(SimpleTestCase):
         doc = etree.parse(filename, parser=parser)
 
         schema = getSchemas(doc=doc)
-        self.assertTrue(type(schema) is etree._Element)
+        self.assertIs(type(schema), etree._Element)
 
     def test_get_schema_from_file(self):
         schema = getSchemas(filename=self.get_simple_valid_xml())
-        self.assertTrue(type(schema) is etree._Element)
+        self.assertIs(type(schema), etree._Element)
 
     def test_get_schema_with_no_argument_should_throw_exception(self):
         with self.assertRaisesRegexp(AttributeError, "'NoneType' object has no attribute 'getroot'"):
@@ -361,7 +361,7 @@ class GenerateFileResponseTests(TestCase):
     def get_headers_from_response(self, response):
         if isinstance(response, FileResponse):
             headers = {}
-            for k, v in response.__dict__.get('_headers').items():
+            for _, v in response.__dict__.get('_headers').items():
                 headers[v[0]] = v[1]
 
             return headers

--- a/ESSArch_Core/util.py
+++ b/ESSArch_Core/util.py
@@ -341,7 +341,7 @@ def get_tree_size_and_count(path='.'):
     total_size = 0
     count = 0
 
-    for dirpath, dirnames, filenames in walk(path):
+    for dirpath, _dirnames, filenames in walk(path):
         for f in filenames:
             try:
                 fp = os.path.join(dirpath, f)

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,0 +1,4 @@
+flake8==3.7.9
+flake8-assertive==1.1.0
+flake8-bugbear==19.8.0
+isort==4.3.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [flake8]
 exclude = .git,__pycache__,node_modules,migrations,versioneer.py,ESSArch_Core/_version.py
 # W504 is mutually exclusive with W503
-ignore = W504
+ignore = W504,B305
 max-line-length = 119
 
 [isort]


### PR DESCRIPTION
[flake8-assertive](https://github.com/jparise/flake8-assertive) encourages usage of the more specific unittest assertions for more precise checks and improved failure messages.

[flake8-bugbear](https://github.com/PyCQA/flake8-bugbear) is used to find "finding likely bugs and design problems". We ignore B305 since it wrongly warns usage of the `.next` method from [crontab](https://pypi.org/project/crontab/).