### PR TITLE
Disable api-check globally

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/scripts/configs/formlyConfig.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/configs/formlyConfig.js
@@ -5,6 +5,9 @@ import inputTemplate from '../../views/formly_templates/form_template_input.html
 import selectTemplate from '../../views/formly_templates/form_template_select.html';
 import uiSelectTemplate from '../../views/formly_templates/ui_select_template.html';
 
+import apiCheck from 'api-check';
+apiCheck.globalConfig.disabled = true;
+
 const formlyConfig = [
   'formlyConfigProvider',
   function(formlyConfigProvider) {


### PR DESCRIPTION
Recommended by angular-formly and the official documentation:

* http://docs.angular-formly.com/docs/tips#section-api-check
* https://github.com/kentcdodds/api-check#disable-apicheck