### PR TITLE
Bump django to 2.2.8

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ crontab==0.22.6
 cryptography==2.8
 daphne==2.4.0
 dj-database-url==0.5.0
-django==2.2.7
+django==2.2.8
 django-cors-headers==3.1.1
 django-countries-plus==1.2.1
 django-filter==2.2.0


### PR DESCRIPTION
[Release notes](https://docs.djangoproject.com/en/stable/releases/2.2.8/)