### PR TITLE
Add ability to attach xml receipt to email receipt

### DIFF
--- a/ESSArch_Core/fixity/receipt/backends/base.py
+++ b/ESSArch_Core/fixity/receipt/backends/base.py
@@ -1,3 +1,3 @@
 class BaseReceiptBackend:
-    def create(self, template, destination, outcome, short_message, message, date, ip=None, task=None):
+    def create(self, template, destination, outcome, short_message, message, date, ip=None, task=None, **kwargs):
         raise NotImplementedError('subclasses of BaseReceiptBackend must provide a create() method')

--- a/ESSArch_Core/fixity/receipt/backends/xml.py
+++ b/ESSArch_Core/fixity/receipt/backends/xml.py
@@ -19,7 +19,7 @@ logger = logging.getLogger('essarch.core.fixity.receipt.xml')
 
 
 class XMLReceiptBackend(BaseReceiptBackend):
-    def create(self, template, destination, outcome, short_message, message, date=None, ip=None, task=None):
+    def create(self, template, destination, outcome, short_message, message, date=None, ip=None, task=None, **kwargs):
         logger.debug('Creating XML receipt: {}'.format(destination))
         spec = json.loads(get_template(template).template.source)
 
@@ -61,3 +61,5 @@ class XMLReceiptBackend(BaseReceiptBackend):
         files_to_create = {destination: {'spec': spec, 'data': data}}
         XMLGenerator().generate(files_to_create)
         logger.info('XML receipt created: {}'.format(destination))
+
+        return destination

--- a/ESSArch_Core/ip/tasks.py
+++ b/ESSArch_Core/ip/tasks.py
@@ -417,7 +417,7 @@ class WriteInformationPackageToSearchIndex(DBTask):
 
 
 class CreateReceipt(DBTask):
-    def run(self, task_id, backend, template, destination, outcome, short_message, message, date=None):
+    def run(self, task_id, backend, template, destination, outcome, short_message, message, date=None, **kwargs):
         ip = self.get_information_package()
         template, destination, outcome, short_message, message, date = self.parse_params(
             template, destination, outcome, short_message, message, date
@@ -430,7 +430,7 @@ class CreateReceipt(DBTask):
             task = self.get_processtask()
         else:
             task = ProcessTask.objects.get(celery_id=task_id)
-        backend.create(template, destination, outcome, short_message, message, date, ip=ip, task=task)
+        return backend.create(template, destination, outcome, short_message, message, date, ip=ip, task=task, **kwargs)
 
 
 class MarkArchived(DBTask):

--- a/ESSArch_Core/profiles/utils.py
+++ b/ESSArch_Core/profiles/utils.py
@@ -44,6 +44,12 @@ class LazyDict(Mapping):
         else:
             return self._raw_dict.__setitem__(key, value)
 
+    def to_dict(self):
+        d = {}
+        for k, v in self._raw_dict.items():
+            d[k] = v
+        return d
+
     def copy(self):
         return LazyDict(self._raw_dict.copy())
 


### PR DESCRIPTION
With the optional parameter `attachments` added to the email backend and the XML backend returning its destination, the following configuration will add the XML receipt as an attachment to the email receipt

```json
[
    {
        "name":"ESSArch_Core.ip.tasks.CreateReceipt",
        "label":"Create XML receipt",
        "reference": "xml_receipt",
        "args": [
            null,
            "xml",
            "receipts/xml.json",
            "/ESSArch/data/receipts/{{_OBJID}}_{% now 'ymdHis' %}.xml",
            "success",
            "Preserved {{OBJID}}",
            "{{OBJID}} is now preserved"
        ],
    },
    {
        "name": "ESSArch_Core.ip.tasks.CreateReceipt",
        "label": "Send email receipt",
        "args": [
            null,
            "email",
            "receipts/email.txt",
            "mail@example.com",
            "success",
            "Preserved {{OBJID}}",
            "{{OBJID}} is now preserved"
        ],
        "result_params": {
            "attachments": ["xml_receipt"]
        }
    }
]
```