### PR TITLE
Fix bug when updating medium list

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/scripts/services/SelectedIPUpdater.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/services/SelectedIPUpdater.js
@@ -25,10 +25,7 @@ const selectedIpUpdater = () => {
         }
       } else if (selectedIp !== null) {
         newIps.forEach(function(ip) {
-          if (
-            !angular.equals(ip, selectedIp) &&
-            (ip.id === selectedIp.id || ip.object_identifier_value === selectedIp.object_identifier_value)
-          ) {
+          if (!angular.equals(ip, selectedIp) && ip.id === selectedIp.id) {
             updateSingleIp(selectedIp, ip);
           }
         });


### PR DESCRIPTION
For some reason this function checked for both equal ID and object_identifier_value, which does not make any sense since both ID and object_identifier_value are unique identifiers