### PR TITLE
Fix bug where archive dropdown list appeared empty

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/AgentArchiveRelationModalInstanceCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/AgentArchiveRelationModalInstanceCtrl.js
@@ -1,16 +1,5 @@
 export default class AgentArchiveRelationModalInstanceCtrl {
-  constructor(
-    $uibModalInstance,
-    appConfig,
-    data,
-    $http,
-    EditMode,
-    $scope,
-    $translate,
-    $filter,
-    $rootScope,
-    ArchiveName
-  ) {
+  constructor($uibModalInstance, appConfig, data, $http, EditMode, $scope, $translate, $rootScope, ArchiveName) {
     const $ctrl = this;
     $ctrl.relationTemplate = {
       description: '',

--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/AgentArchiveRelationModalInstanceCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/AgentArchiveRelationModalInstanceCtrl.js
@@ -1,5 +1,16 @@
 export default class AgentArchiveRelationModalInstanceCtrl {
-  constructor($uibModalInstance, appConfig, data, $http, EditMode, $scope, $translate, $filter, $rootScope) {
+  constructor(
+    $uibModalInstance,
+    appConfig,
+    data,
+    $http,
+    EditMode,
+    $scope,
+    $translate,
+    $filter,
+    $rootScope,
+    ArchiveName
+  ) {
     const $ctrl = this;
     $ctrl.relationTemplate = {
       description: '',
@@ -38,19 +49,8 @@ export default class AgentArchiveRelationModalInstanceCtrl {
         url: appConfig.djangoUrl + 'tags/',
         mathod: 'GET',
         params: {page: 1, page_size: 10, index: 'archive', search: search},
-      }).then(function(response) {
-        $ctrl.options.archives = response.data.map(function(x) {
-          x.current_version.name_with_dates =
-            x.current_version.name +
-            (x.current_version.start_date !== null || x.current_version.end_date != null
-              ? ' (' +
-                (x.current_version.start_date !== null ? $filter('date')(x.current_version.start_date, 'yyyy') : '') +
-                ' - ' +
-                (x.current_version.end_date !== null ? $filter('date')(x.current_version.end_date, 'yyyy') : '') +
-                ')'
-              : '');
-          return x.current_version;
-        });
+      }).then(response => {
+        $ctrl.options.archives = ArchiveName.parseArchiveNames(response.data);
         return $ctrl.options.archives;
       });
     };

--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/PlaceNodeInArchiveModalInstanceCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/PlaceNodeInArchiveModalInstanceCtrl.js
@@ -1,5 +1,5 @@
 export default class PlaceNodeInArchiveModalInstanceCtrl {
-  constructor($uibModalInstance, $scope, $translate, $http, appConfig, data, EditMode, StructureName) {
+  constructor($uibModalInstance, $scope, $translate, $http, appConfig, data, EditMode, StructureName, ArchiveName) {
     const $ctrl = this;
     $ctrl.archiveFields = [];
     $ctrl.structureFields = [];
@@ -20,18 +20,7 @@ export default class PlaceNodeInArchiveModalInstanceCtrl {
         mathod: 'GET',
         params: {page: 1, page_size: 10, index: 'archive', search: search},
       }).then(function(response) {
-        $ctrl.options.archive = response.data.map(function(x) {
-          x.current_version.name_with_dates =
-            x.current_version.name +
-            (x.current_version.start_date !== null || x.current_version.end_date != null
-              ? ' (' +
-                (x.current_version.start_date !== null ? $filter('date')(x.current_version.start_date, 'yyyy') : '') +
-                ' - ' +
-                (x.current_version.end_date !== null ? $filter('date')(x.current_version.end_date, 'yyyy') : '') +
-                ')'
-              : '');
-          return x.current_version;
-        });
+        $ctrl.options.archive = ArchiveName.parseArchiveNames(response.data);
         return $ctrl.options.archive;
       });
     };

--- a/ESSArch_Core/frontend/static/frontend/scripts/controllers/StructureUnitRelationModalInstanceCtrl.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/controllers/StructureUnitRelationModalInstanceCtrl.js
@@ -9,7 +9,8 @@ export default class StructureUnitRelationModalInstanceCtrl {
     $scope,
     $rootScope,
     StructureName,
-    $timeout
+    $timeout,
+    ArchiveName
   ) {
     const $ctrl = this;
     $ctrl.data = data;
@@ -55,19 +56,8 @@ export default class StructureUnitRelationModalInstanceCtrl {
         url: appConfig.djangoUrl + 'tags/',
         mathod: 'GET',
         params: {page: 1, page_size: 10, index: 'archive', search: search},
-      }).then(function(response) {
-        $ctrl.options.archive = response.data.map(function(x) {
-          x.current_version.name_with_dates =
-            x.current_version.name +
-            (x.current_version.start_date !== null || x.current_version.end_date != null
-              ? ' (' +
-                (x.current_version.start_date !== null ? $filter('date')(x.current_version.start_date, 'yyyy') : '') +
-                ' - ' +
-                (x.current_version.end_date !== null ? $filter('date')(x.current_version.end_date, 'yyyy') : '') +
-                ')'
-              : '');
-          return x.current_version;
-        });
+      }).then(response => {
+        $ctrl.options.archive = ArchiveName.parseArchiveNames(response.data);
         return $ctrl.options.archive;
       });
     };

--- a/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.controllers.module.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.controllers.module.js
@@ -199,6 +199,7 @@ export default angular
     '$translate',
     '$filter',
     '$rootScope',
+    'ArchiveName',
     AgentArchiveRelationModalInstanceCtrl,
   ])
   .controller('AgentIdentifierModalInstanceCtrl', [
@@ -713,6 +714,7 @@ export default angular
     'data',
     'EditMode',
     'StructureName',
+    'ArchiveName',
     PlaceNodeInArchiveModalInstanceCtrl,
   ])
   .controller('ProfileManagerCtrl', ['$state', '$scope', ProfileManagerCtrl])
@@ -933,6 +935,7 @@ export default angular
     '$rootScope',
     'StructureName',
     '$timeout',
+    'ArchiveName',
     StructureUnitRelationModalInstanceCtrl,
   ])
   .controller('StructureVersionModalInstanceCtrl', [

--- a/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.controllers.module.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.controllers.module.js
@@ -197,7 +197,6 @@ export default angular
     'EditMode',
     '$scope',
     '$translate',
-    '$filter',
     '$rootScope',
     'ArchiveName',
     AgentArchiveRelationModalInstanceCtrl,

--- a/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.services.module.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.services.module.js
@@ -1,4 +1,5 @@
 import agentName from '../services/agentName';
+import archiveName from '../services/archiveName';
 import myService from '../services/myService';
 import appraisal from '../services/appraisal';
 import storagePolicy from '../services/storagePolicy';
@@ -46,6 +47,7 @@ import {workarea, workareaFiles} from '../services/workarea';
 export default angular
   .module('essarch.services', [])
   .factory('AgentName', ['$filter', agentName])
+  .factory('ArchiveName', ['$filter', archiveName])
   .factory('myService', ['PermPermissionStore', 'djangoAuth', myService])
   .factory('Appraisal', ['$http', 'appConfig', appraisal])
   .factory('Filters', ['$translate', '$rootScope', '$http', 'appConfig', filters])

--- a/ESSArch_Core/frontend/static/frontend/scripts/services/archiveName.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/services/archiveName.js
@@ -1,0 +1,29 @@
+const ArchiveName = $filter => {
+  let getNameWithDates = archive => {
+    archive.current_version.name_with_dates =
+      archive.current_version.name +
+      (archive.current_version.start_date !== null || archive.current_version.end_date != null
+        ? ' (' +
+          (archive.current_version.start_date !== null
+            ? $filter('date')(archive.current_version.start_date, 'yyyy')
+            : '') +
+          ' - ' +
+          (archive.current_version.end_date !== null
+            ? $filter('date')(archive.current_version.end_date, 'yyyy')
+            : '') +
+          ')'
+        : '');
+    return archive.current_version;
+  };
+  return {
+    getNameWithDates: getNameWithDates,
+    parseArchiveNames: archives => {
+      let archiveList = archives.map(archive => {
+        return getNameWithDates(archive);
+      });
+      return archiveList;
+    },
+  };
+};
+
+export default ArchiveName;


### PR DESCRIPTION
* Solves bug where archive dropdown list appeared empty when the list contained archives with start/end-dates. Caused by missing $filter injection.

* Extract function for archive names with dates to own service so that it can be reused without getting the same error.