### PR TITLE
Update datepicker

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
+++ b/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
@@ -16,6 +16,8 @@
   <a class="dropdown-toggle" id="dropdown-{{options.key}}" role="button" uib-dropdown-toggle>
     <div class="input-group">
       <input
+        ng-focus="status[options.key] = true"
+        ng-click="status[options.key] = false"
         ng-change="to.onChange"
         set-touched="options.formControl"
         id="{{::id}}"

--- a/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
+++ b/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
@@ -24,6 +24,7 @@
         type="text"
         data-date-time-input="{{options.templateOptions.dateFormat ? options.templateOptions.dateFormat : 'YYYY-MM-DD'}}"
         data-model-type="{{options.templateOptions.dateFormat ? options.templateOptions.dateFormat : 'Date'}}"
+        data-date-formats="['YYYY-MMM-DD', 'YYYY', 'YYYY-MM']"
         class="form-control"
         data-ng-model="model[options.key]"
         autocomplete="off"

--- a/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
+++ b/ESSArch_Core/frontend/static/frontend/views/formly_templates/datepicker_template.html
@@ -27,11 +27,13 @@
         class="form-control"
         data-ng-model="model[options.key]"
         autocomplete="off"
+        ng-disabled="to.disabled"
       /><span class="input-group-addon"><i class="fas fa-calendar-alt"></i></span>
     </div>
   </a>
   <ul class="dropdown-menu" role="menu" aria-labelledby="dLabel" uib-dropdown-menu>
     <datetimepicker
+      ng-disabled="to.disabled"
       data-ng-model="model[options.key]"
       ng-change="status[options.key] = false"
       ng-required="options.templateOptions.required"


### PR DESCRIPTION
* Add ability to fully disable datepicker
* Add support for entering only year or year + month and auto fill the rest
* Open the datepicker on focus as well as click and close when tabbing to next one

Still not working
- Does not yet close datepicker if user tabs to a non datepicker field
- End date auto fill functionality (example: "2020-12-31" instead of "2020 -01-01")