### PR TITLE
Add error propagation to eager tasks

### DIFF
--- a/ESSArch_Core/WorkflowEngine/dbtask.py
+++ b/ESSArch_Core/WorkflowEngine/dbtask.py
@@ -26,14 +26,10 @@ import logging
 
 from billiard.einfo import ExceptionInfo
 from celery import exceptions, states as celery_states
-from celery.result import EagerResult
 from celery.task.base import Task
-from celery.utils.functional import maybe_list
-from celery.utils.nodenames import gethostname
 from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.utils import translation
-from kombu.utils.uuid import uuid
 
 from ESSArch_Core.essxml.Generator.xmlGenerator import parseContent
 from ESSArch_Core.ip.models import EventIP, InformationPackage
@@ -197,61 +193,6 @@ class DBTask(Task):
         }
         logger.log(level, outcome_detail_note, extra=extra)
 
-    @classmethod
-    def apply(self, args=None, kwargs=None,
-              link=None, link_error=None,
-              task_id=None, retries=None, throw=None,
-              logfile=None, loglevel=None, headers=None, **options):
-        """Execute this task locally, by blocking until the task returns.
-        We override this simply to be able to call build_tracer with eager=False
-
-        Arguments:
-            args (Tuple): positional arguments passed on to the task.
-            kwargs (Dict): keyword arguments passed on to the task.
-            throw (bool): Re-raise task exceptions.
-                Defaults to the :setting:`task_eager_propagates` setting.
-
-        Returns:
-            celery.result.EagerResult: pre-evaluated result.
-        """
-        # trace imports Task, so need to import inline.
-        from celery.app.trace import build_tracer
-
-        app = self._get_app()
-        args = args or ()
-        kwargs = kwargs or {}
-        task_id = task_id or uuid()
-        retries = retries or 0
-        if throw is None:
-            throw = app.conf.task_eager_propagates
-
-        # Make sure we get the task instance, not class.
-        task = app._tasks[self.name]
-
-        request = {
-            'id': task_id,
-            'retries': retries,
-            'is_eager': True,
-            'logfile': logfile,
-            'loglevel': loglevel or 0,
-            'hostname': gethostname(),
-            'callbacks': maybe_list(link),
-            'errbacks': maybe_list(link_error),
-            'headers': headers,
-            'delivery_info': {'is_eager': True},
-        }
-        tb = None
-        tracer = build_tracer(
-            task.name, task, eager=False,
-            propagate=throw, app=self._get_app(),
-        )
-        ret = tracer(task_id, args, kwargs, request)
-        retval = ret.retval
-        if isinstance(retval, ExceptionInfo):
-            retval, tb = retval.exception, retval.traceback
-        state = celery_states.SUCCESS if ret.info is None else ret.info.state
-        return EagerResult(task_id, retval, state, traceback=tb)
-
     def failure(self, exc, task_id, args, kwargs, einfo):
         '''
         We use our own version of on_failure so that we can call it at the end
@@ -259,6 +200,13 @@ class DBTask(Task):
         needed to give objects created here (e.g. events) the correct
         timestamps
         '''
+
+        if getattr(self, 'eager', True):
+            self.update_state(task_id=task_id, state=celery_states.FAILURE)
+            self.backend._store_result(
+                task_id, self.backend.prepare_exception(exc),
+                celery_states.FAILURE, traceback=einfo.traceback,
+            )
 
         if self.event_type:
             self.create_event(task_id, celery_states.FAILURE, args, kwargs, None, einfo)
@@ -270,6 +218,10 @@ class DBTask(Task):
         needed to give objects created here (e.g. events) the correct
         timestamps
         '''
+
+        if getattr(self, 'eager', True):
+            self.update_state(task_id=task_id, state=celery_states.SUCCESS)
+            self.backend.store_result(task_id, retval, celery_states.SUCCESS)
 
         if self.event_type:
             self.create_event(task_id, celery_states.SUCCESS, args, kwargs, retval, None)

--- a/ESSArch_Core/WorkflowEngine/tests/test_steps.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_steps.py
@@ -41,7 +41,6 @@ from ESSArch_Core.WorkflowEngine.util import create_workflow
 class test_status(TestCase):
     def setUp(self):
         settings.CELERY_ALWAYS_EAGER = True
-        settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
         self.step = ProcessStep.objects.create()
 
@@ -206,6 +205,7 @@ class test_status(TestCase):
         with self.assertNumQueries(13):
             self.assertEqual(self.step.status, celery_states.SUCCESS)
 
+    @TaskRunner(False)
     def test_cached_status_resume_step(self):
         fname = os.path.join(self.test_dir, "foo.txt")
 
@@ -393,7 +393,6 @@ class test_status(TestCase):
 class test_progress(TestCase):
     def setUp(self):
         settings.CELERY_ALWAYS_EAGER = True
-        settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
         self.step = ProcessStep.objects.create()
 

--- a/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
+++ b/ESSArch_Core/WorkflowEngine/tests/test_tasks.py
@@ -262,6 +262,7 @@ class DBTaskTests(TestCase):
     @mock.patch("ESSArch_Core.WorkflowEngine.dbtask.logger.log")
     def test_create_event_when_success(self, mocked_logger_log):
         db_task = DBTask()
+        db_task.eager = False
         t = ProcessTask.objects.create()
 
         db_task.create_event(
@@ -287,6 +288,7 @@ class DBTaskTests(TestCase):
     @mock.patch("billiard.einfo.ExceptionInfo")
     def test_create_event_when_failure(self, mock_einfo, mock_logger_log):
         db_task = DBTask()
+        db_task.eager = False
         t = ProcessTask.objects.create()
 
         db_task.create_event(
@@ -311,6 +313,7 @@ class DBTaskTests(TestCase):
     def test_success_when_event_type_not_none_then_create_event(self, mock_create_event):
         db_task = DBTask()
         db_task.event_type = 123
+        db_task.eager = False
         task_id = uuid.uuid4()
         retval = uuid.uuid4()
         args = uuid.uuid4()
@@ -324,6 +327,7 @@ class DBTaskTests(TestCase):
     def test_success_when_event_type_is_none_dont_create_event(self, mock_create_event):
         db_task = DBTask()
         db_task.event_type = None
+        db_task.eager = False
         task_id = uuid.uuid4()
         retval = uuid.uuid4()
         args = uuid.uuid4()
@@ -337,6 +341,7 @@ class DBTaskTests(TestCase):
     def test_success_when_track_is_False_then_return(self, mock_create_event):
         db_task = DBTask()
         db_task.track = False
+        db_task.eager = False
         task_id = uuid.uuid4()
         retval = uuid.uuid4()
         args = uuid.uuid4()
@@ -351,6 +356,7 @@ class DBTaskTests(TestCase):
     def test_failure_when_event_type_not_none_then_create_event(self, mock_create_event, mock_einfo):
         db_task = DBTask()
         db_task.event_type = 123
+        db_task.eager = False
         task_id = uuid.uuid4()
         args = uuid.uuid4()
         kwargs = uuid.uuid4()
@@ -366,6 +372,7 @@ class DBTaskTests(TestCase):
     def test_failure_when_event_type_is_none_then_dont_create_event(self, create_event, mock_einfo):
         db_task = DBTask()
         db_task.event_type = None
+        db_task.eager = False
         task_id = uuid.uuid4()
         args = uuid.uuid4()
         kwargs = uuid.uuid4()
@@ -381,6 +388,7 @@ class DBTaskTests(TestCase):
     def test_failure_when_track_is_False_then_return(self, mock_create_event, mock_einfo):
         db_task = DBTask()
         db_task.track = False
+        db_task.eager = False
         task_id = uuid.uuid4()
         args = uuid.uuid4()
         kwargs = uuid.uuid4()

--- a/ESSArch_Core/celery/backends/database.py
+++ b/ESSArch_Core/celery/backends/database.py
@@ -68,12 +68,15 @@ class DatabaseBackend(BaseDictBackend):
         return result
 
     def update_state(self, task_id, meta, status, request=None):
-        progress = (meta['current'] / meta['total']) * 100
+        if meta is not None:
+            progress = (meta['current'] / meta['total']) * 100
+        else:
+            progress = None
 
         ProcessTask.objects.filter(celery_id=task_id).update(
             status=status if status is not None else F('status'),
-            meta=meta,
-            progress=progress,
+            meta=meta if meta is not None else F('meta'),
+            progress=progress if progress is not None else F('progress'),
         )
         return status
 

--- a/ESSArch_Core/ip/tests/test_ips.py
+++ b/ESSArch_Core/ip/tests/test_ips.py
@@ -3531,7 +3531,7 @@ class test_set_uploaded(TestCase):
         self.ip.refresh_from_db()
         self.assertEqual(self.ip.state, 'Uploading')
 
-    @TaskRunner()
+    @TaskRunner(propagate=False)
     def test_set_uploaded_with_permission(self):
         InformationPackage.objects.filter(pk=self.ip.pk).update(
             responsible=self.user

--- a/ESSArch_Core/testing/runner.py
+++ b/ESSArch_Core/testing/runner.py
@@ -15,9 +15,13 @@ class QuietTestRunner(DiscoverRunner):
 
 
 @contextmanager
-def TaskRunner():
+def TaskRunner(propagate=True):
     settings.CELERY_TASK_ALWAYS_EAGER = True
     current_app.conf.CELERY_TASK_ALWAYS_EAGER = True
+    settings.CELERY_TASK_EAGER_PROPAGATES = propagate
+    current_app.conf.CELERY_TASK_EAGER_PROPAGATES = propagate
     yield
     current_app.conf.CELERY_TASK_ALWAYS_EAGER = False
     settings.CELERY_TASK_ALWAYS_EAGER = False
+    settings.CELERY_TASK_EAGER_PROPAGATES = False
+    current_app.conf.CELERY_TASK_EAGER_PROPAGATES = False


### PR DESCRIPTION
This PR removes the customized version of DBTask.apply() and instead uses DBTask.success and DBTask.failure to update the database when eager tasks succeeds or fails.

By using the built-in DBTask.apply() we get proper task propagation that is better suited for testing