### PR TITLE
[Merged by Bors] - Let mimetypes itself initialize the default list to allow for easier customization

### DIFF
--- a/ESSArch_Core/fixity/format.py
+++ b/ESSArch_Core/fixity/format.py
@@ -57,7 +57,6 @@ class FormatIdentifier:
 
         logger.debug('Initiating default mimetypes')
         mimetypes.init()
-        mimetypes._default_mime_types()
         logger.info('Initiated default mimetypes')
 
     def get_mimetype(self, fname):


### PR DESCRIPTION
This allows users to easier add a small set of types in their local settings file instead of setting `mimetypes_definitionfile`, e.g on macOS it might be required to do the following:

```
import mimetypes
mimetypes.add_type("application/xml", ".xsd", True)
```