### PR TITLE
Cleanup, fix and test ArchiveWriteSerializer and ComponentWriteSerializer

### DIFF
--- a/ESSArch_Core/tags/serializers.py
+++ b/ESSArch_Core/tags/serializers.py
@@ -892,9 +892,47 @@ class TransferEditNodesSerializer(serializers.Serializer):
     )
 
 
-class ComponentWriteSerializer(serializers.Serializer):
+class NodeWriteSerializer(serializers.Serializer):
     name = serializers.CharField()
     description = serializers.CharField(required=False)
+    start_date = serializers.DateTimeField(required=False, allow_null=True)
+    end_date = serializers.DateTimeField(required=False, allow_null=True)
+    custom_fields = serializers.JSONField(required=False)
+    notes = NodeNoteWriteSerializer(many=True, required=False)
+    identifiers = NodeIdentifierWriteSerializer(many=True, required=False)
+
+    @staticmethod
+    def create_notes(tag_version: TagVersion, notes_data):
+        NodeNote.objects.bulk_create([
+            NodeNote(tag_version=tag_version, **note)
+            for note in notes_data
+        ])
+
+    @staticmethod
+    def create_identifiers(tag_version: TagVersion, identifiers_data):
+        NodeIdentifier.objects.bulk_create([
+            NodeIdentifier(tag_version=tag_version, **identifier)
+            for identifier in identifiers_data
+        ])
+
+    @staticmethod
+    @transaction.atomic
+    def update_notes(tag_version: TagVersion, notes_data):
+        if notes_data is not None:
+            NodeNote.objects.filter(tag_version=tag_version).delete()
+            for note in notes_data:
+                note.setdefault('create_date', timezone.now())
+            NodeWriteSerializer.create_notes(tag_version, notes_data)
+
+    @staticmethod
+    @transaction.atomic
+    def update_identifiers(tag_version: TagVersion, identifiers_data):
+        if identifiers_data is not None:
+            NodeIdentifier.objects.filter(tag_version=tag_version).delete()
+            NodeWriteSerializer.create_identifiers(tag_version, identifiers_data)
+
+
+class ComponentWriteSerializer(NodeWriteSerializer):
     type = serializers.PrimaryKeyRelatedField(queryset=TagVersionType.objects.filter(archive_type=False))
     reference_code = serializers.CharField()
     information_package = serializers.PrimaryKeyRelatedField(
@@ -910,25 +948,6 @@ class ComponentWriteSerializer(serializers.Serializer):
         required=False,
         queryset=StructureUnit.objects.filter(structure__is_template=False),
     )
-    start_date = serializers.DateTimeField(required=False, allow_null=True)
-    end_date = serializers.DateTimeField(required=False, allow_null=True)
-    custom_fields = serializers.JSONField(required=False)
-    notes = NodeNoteWriteSerializer(many=True, required=False)
-    identifiers = NodeIdentifierWriteSerializer(many=True, required=False)
-
-    @staticmethod
-    def create_notes(tag_version, notes_data):
-        NodeNote.objects.bulk_create([
-            NodeNote(tag_version=tag_version, **note)
-            for note in notes_data
-        ])
-
-    @staticmethod
-    def create_identifiers(tag_version, identifiers_data):
-        NodeIdentifier.objects.bulk_create([
-            NodeIdentifier(tag_version=tag_version, **identifier)
-            for identifier in identifiers_data
-        ])
 
     def create(self, validated_data):
         with transaction.atomic():
@@ -987,8 +1006,8 @@ class ComponentWriteSerializer(serializers.Serializer):
                 new_unit = related if tag_structure.structure_unit is not None else None
                 tag_structure.copy_to_new_structure(related.structure, new_unit=new_unit)
 
-            self.create_identifiers(self, identifiers_data)
-            self.create_notes(self, notes_data)
+            self.create_identifiers(tag_version, identifiers_data)
+            self.create_notes(tag_version, notes_data)
 
         doc = Component.from_obj(tag_version)
         doc.save()
@@ -1001,18 +1020,11 @@ class ComponentWriteSerializer(serializers.Serializer):
         structure = validated_data.pop('structure', None)
         notes_data = validated_data.pop('notes', None)
         identifiers_data = validated_data.pop('identifiers', None)
-        information_package = validated_data.pop('information_package', None)
+        information_package = validated_data.pop('information_package', instance.tag.information_package)
         validated_data.pop('index', None)
 
-        if identifiers_data is not None:
-            NodeIdentifier.objects.filter(tag_version=instance).delete()
-            self.create_identifiers(instance, identifiers_data)
-
-        if notes_data is not None:
-            NodeNote.objects.filter(tag_version=instance).delete()
-            for note in notes_data:
-                note.setdefault('create_date', timezone.now())
-            self.create_notes(instance, notes_data)
+        self.update_identifiers(instance, identifiers_data)
+        self.update_notes(instance, notes_data)
 
         if structure is not None:
             tag = instance.tag
@@ -1086,36 +1098,15 @@ class ComponentWriteSerializer(serializers.Serializer):
         return data
 
 
-class ArchiveWriteSerializer(serializers.Serializer):
-    name = serializers.CharField()
+class ArchiveWriteSerializer(NodeWriteSerializer):
     type = serializers.PrimaryKeyRelatedField(queryset=TagVersionType.objects.filter(archive_type=True))
     structures = serializers.PrimaryKeyRelatedField(
         queryset=Structure.objects.filter(is_template=True, published=True),
         many=True,
     )
     archive_creator = serializers.PrimaryKeyRelatedField(queryset=Agent.objects.all())
-    description = serializers.CharField(required=False)
     reference_code = serializers.CharField(required=False, allow_blank=True)
     use_uuid_as_refcode = serializers.BooleanField(default=False)
-    start_date = serializers.DateTimeField(required=False, allow_null=True)
-    end_date = serializers.DateTimeField(required=False, allow_null=True)
-    custom_fields = serializers.JSONField(required=False)
-    notes = NodeNoteWriteSerializer(many=True, required=False)
-    identifiers = NodeIdentifierWriteSerializer(many=True, required=False)
-
-    @staticmethod
-    def create_notes(tag_version, notes_data):
-        NodeNote.objects.bulk_create([
-            NodeNote(tag_version=tag_version, **note)
-            for note in notes_data
-        ])
-
-    @staticmethod
-    def create_identifiers(tag_version, identifiers_data):
-        NodeIdentifier.objects.bulk_create([
-            NodeIdentifier(tag_version=tag_version, **identifier)
-            for identifier in identifiers_data
-        ])
 
     def create(self, validated_data):
         with transaction.atomic():
@@ -1150,8 +1141,8 @@ class ArchiveWriteSerializer(serializers.Serializer):
                 creator=True, defaults={'name': 'creator'}
             )
             AgentTagLink.objects.create(agent=agent, tag=tag_version, type=tag_link_type)
-            self.create_identifiers(self, identifiers_data)
-            self.create_notes(self, notes_data)
+            self.create_identifiers(tag_version, identifiers_data)
+            self.create_notes(tag_version, notes_data)
 
         doc = Archive.from_obj(tag_version)
         doc.save()
@@ -1163,15 +1154,8 @@ class ArchiveWriteSerializer(serializers.Serializer):
         notes_data = validated_data.pop('notes', None)
         identifiers_data = validated_data.pop('identifiers', None)
 
-        if identifiers_data is not None:
-            NodeIdentifier.objects.filter(tag_version=instance).delete()
-            self.create_identifiers(instance, identifiers_data)
-
-        if notes_data is not None:
-            NodeNote.objects.filter(tag_version=instance).delete()
-            for note in notes_data:
-                note.setdefault('create_date', timezone.now())
-            self.create_notes(instance, notes_data)
+        self.update_identifiers(instance, identifiers_data)
+        self.update_notes(instance, notes_data)
 
         with transaction.atomic():
             for structure in structures:


### PR DESCRIPTION
Fixes arguments sent to create_identifiers and create_notes as well as correctly setting default value for `information_package` when updating component