### PR TITLE
Bump codecov action to 1.0.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,9 +219,8 @@ jobs:
         run: |
           coverage xml
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.5
+        uses: codecov/codecov-action@v1.0.6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           name: Windows
           file: ./coverage.xml
           flags: backend
@@ -384,9 +383,8 @@ jobs:
         run: |
           coverage xml
       - name: Codecov
-        uses: codecov/codecov-action@v1.0.5
+        uses: codecov/codecov-action@v1.0.6
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           name: Linux (${{matrix.db}})
           file: ./coverage.xml
           flags: backend


### PR DESCRIPTION
[Release notes](https://github.com/codecov/codecov-action/releases/tag/v1.0.6)