### PR TITLE
[Merged by Bors] - Fix parallel flag on steps in workflow spec

### DIFF
--- a/ESSArch_Core/WorkflowEngine/util.py
+++ b/ESSArch_Core/WorkflowEngine/util.py
@@ -55,6 +55,7 @@ def _create_step(parent_step, flow, ip, responsible, context=None):
 
             child_s = ProcessStep.objects.create(
                 name=flow_entry['name'],
+                parallel=flow_entry.get('parallel', False),
                 parent_step=parent_step,
                 parent_step_pos=e_idx,
                 eager=parent_step.eager,


### PR DESCRIPTION
The `parallel` flag was previously not used