### PR TITLE
Remove failing request for custom logo

### DIFF
--- a/ESSArch_Core/frontend/static/frontend/views/home.html
+++ b/ESSArch_Core/frontend/static/frontend/views/home.html
@@ -3,7 +3,7 @@
     <div class="logo-user-wrapper">
       <div class="logo" ng-controller="UtilCtrl">
         <div ng-if="!angular.isUndefined(site) && site !== null && site.logo !== null" class="custom-logo">
-          <img src="{{site.logo}}" width="36" alt="logo" />
+          <img ng-src="{{site.logo}}" width="36" alt="logo" />
         </div>
       </div>
       <h3 class="page-title" ng-class="{'page-title-with-logo': site.logo}" ng-click="infoPage()">ESSArch</h3>


### PR DESCRIPTION
From the [documentation](https://docs.angularjs.org/api/ng/directive/ngSrc):

> Using AngularJS markup like {{hash}} in a src attribute doesn't work right: The browser will fetch from the URL with the literal text {{hash}} until AngularJS replaces the expression inside {{hash}}. The ngSrc directive solves this problem.