### PR TITLE
Invalidate template cache when commit hash changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,4 +8,3 @@ node_modules
 *.egg-info/
 /MANIFEST
 /.idea/
-.git/

--- a/ESSArch_Core/frontend/static/frontend/scripts/configs/preventTemplateCache.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/configs/preventTemplateCache.js
@@ -1,0 +1,26 @@
+const preventTemplateCache = [
+  '$provide',
+  '$httpProvider',
+  '$windowProvider',
+  function ($provide, $httpProvider, $windowProvider) {
+    $provide.factory('preventTemplateCache', [
+      '$q',
+      '$location',
+      '$rootScope',
+      '$injector',
+      function ($q, $location, $rootScope, $injector) {
+        return {
+          request: function (config) {
+            if (config.url.indexOf('views') !== -1) {
+              config.url = config.url + '?t=' + COMMITHASH;
+            }
+            return config;
+          },
+        };
+      },
+    ]);
+    $httpProvider.interceptors.push('preventTemplateCache');
+  },
+];
+
+export default preventTemplateCache;

--- a/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.configs.module.js
+++ b/ESSArch_Core/frontend/static/frontend/scripts/modules/essarch.configs.module.js
@@ -1,5 +1,6 @@
 import FormlyConfig from '../configs/formlyConfig';
 import HttpInterceptor from '../configs/httpInterceptor';
+import PreventTemplateCache from '../configs/preventTemplateCache';
 import UiSelectConfig from '../configs/uiSelectConfig';
 import PropsFilter from '../filters/propsFilter';
 
@@ -7,5 +8,6 @@ export default angular
   .module('essarch.configs', ['pascalprecht.translate'])
   .config(FormlyConfig)
   .config(HttpInterceptor)
+  .config(PreventTemplateCache)
   .config(UiSelectConfig)
   .filter('propsFilter', PropsFilter).name;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:lts-alpine AS build-frontend
 
 WORKDIR /code
-RUN apk update && apk add g++ make python
+RUN apk update && apk add g++ git make python
 COPY package.json yarn.lock webpack.common.babel.js webpack.dev.babel.js tsconfig.json ./
 RUN yarn
 COPY ESSArch_Core/frontend/static/frontend /code/ESSArch_Core/frontend/static/frontend
+COPY ./.git .git
 RUN yarn build:dev
 
 FROM python:3.7-buster as base

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "expose-loader": "^0.7.5",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^4.0.3",
+    "git-revision-webpack-plugin": "^3.0.4",
     "html-loader": "^1.0.0",
     "imports-loader": "^0.8.0",
     "jquery": "^3.3.1",

--- a/webpack.common.babel.js
+++ b/webpack.common.babel.js
@@ -4,6 +4,8 @@ const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
 const OptimizeCssnanoPlugin = require('@intervolga/optimize-cssnano-plugin');
+const GitRevisionPlugin = require('git-revision-webpack-plugin');
+const gitRevisionPlugin = new GitRevisionPlugin();
 
 const basedir = path.resolve(__dirname, 'ESSArch_Core/frontend/static/frontend');
 
@@ -132,7 +134,10 @@ module.exports = (env, argv) => {
       }),
       new ManifestPlugin({fileName: 'rev-manifest.json'}),
       new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/),
-      new webpack.DefinePlugin({'process.env': {LATER_COV: false}}),
+      new webpack.DefinePlugin({
+        'process.env': {LATER_COV: false},
+        COMMITHASH: JSON.stringify(gitRevisionPlugin.commithash()),
+      }),
     ],
     node: {
       fs: 'empty',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,6 +3972,11 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+git-revision-webpack-plugin@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/git-revision-webpack-plugin/-/git-revision-webpack-plugin-3.0.4.tgz#ed1eaad094d6956d3299381050a5a50f662550bd"
+  integrity sha512-ym4Zkl32HtTRZVVgl1KoE+sWtgeFyDjN3vaBQfn8cCv1btAX7rdDY9tgpv4Zi+yxq150pp+pUkGH9L1lRpZOUg==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"


### PR DESCRIPTION
This extends the requested url for each template with the commit hash used when the frontend was last built. This makes the browser invalidate the cached template whenever a new build is made.