### PR TITLE
Sort content of archived IPs alphabetically

### DIFF
--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -2109,7 +2109,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
 
             # a directory with the path exists, get the content of it
             s = Search(index=['directory', 'document'])
-            s = s.filter('term', **{'ip': str(ip.pk)}).query('term', **{'href': path})
+            s = s.filter('term', **{'ip': str(ip.pk)}).query('term', **{'href': path}).sort('type', 'name.keyword')
 
             if self.paginator is not None:
                 # Paginate in search engine

--- a/ESSArch_Core/ip/views.py
+++ b/ESSArch_Core/ip/views.py
@@ -2109,7 +2109,7 @@ class InformationPackageViewSet(viewsets.ModelViewSet):
 
             # a directory with the path exists, get the content of it
             s = Search(index=['directory', 'document'])
-            s = s.filter('term', **{'ip': str(ip.pk)}).query('term', **{'href': path}).sort('type', 'name.keyword')
+            s = s.filter('term', **{'ip': str(ip.pk)}).query('term', **{'href': path}).sort('name.keyword')
 
             if self.paginator is not None:
                 # Paginate in search engine


### PR DESCRIPTION
## Description
Sort the content of an archived IP alphabetically based on file/directory name. This matches the behavior when the IP is not archived and the files are just in a directory.
